### PR TITLE
Add concept of null feature IDs

### DIFF
--- a/extensions/2.0/Vendor/EXT_feature_metadata/README.md
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/README.md
@@ -38,6 +38,7 @@ This extension is optional, meaning it should be placed in the `extensionsUsed` 
     - [Implicit Feature IDs](#implicit-feature-ids)
   - [Feature ID Textures](#feature-id-textures)
   - [Feature ID Instance Attributes](#feature-id-instance-attributes)
+  - [Null Feature IDs](#null-feature-ids)
 - [Feature Metadata](#feature-metadata)
   - [Schemas](#schemas)
   - [Feature Tables](#feature-tables)
@@ -233,6 +234,31 @@ Feature IDs may also be assigned to individual instances when using the [`EXT_me
           }
         }
       }
+    }
+  ]
+}
+```
+
+### Null Feature IDs
+
+It is possible to identify sections of a mesh or texture as not belonging to any feature. These vertices or texels are assigned the `nullFeatureId` value.
+
+`nullFeatureId` must be a whole number greater than or equal to `count`, where `count` is the total number of features in the feature table.
+
+This is useful for marking sections of a model that have not been semantically labelled. For example if a computer vision algorithm is trained to identify doors and sees ten doors on a textured building model, "door" texels would be assigned feature IDs [0, 9] and all other texels would be assigned the `nullFeatureId` value, in this case 10.
+
+```jsonc
+"EXT_feature_metadata": {
+  "featureIdTextures": [
+    {
+      "featureTable": "doors",
+      "featureIds": {
+        "texture": {
+          "index": 0
+        },
+        "channels": "r"
+      },
+      "nullFeatureId": 10
     }
   ]
 }

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdAttribute.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdAttribute.schema.json
@@ -10,7 +10,11 @@
     },
     "featureIds": {
       "allOf": [ { "$ref": "featureIdAttribute.featureIds.schema.json" } ],
-      "description": "An object describing feature IDs to be used as indices to property arrays in the feature table. Feature IDs must be whole numbers in the range `[0, count - 1]` (inclusive), where `count` is the total number of features in the feature table."
+      "description": "An object describing feature IDs to be used as indices to property arrays in the feature table. Feature IDs must be whole numbers in the range `[0, count - 1]` (inclusive), where `count` is the total number of features in the feature table, or must equal `nullFeatureID` to indicate that no feature is assigned."
+    },
+    "nullFeatureId": {
+      "type": "number",
+      "description": "A value in the feature ID attribute that indicates that no feature is assigned. Must be a whole number greater than or equal to `count`, where `count` is the total number of features in the feature table."
     },
     "extensions": {},
     "extras": {}

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdTexture.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdTexture.schema.json
@@ -10,7 +10,11 @@
     },
     "featureIds": {
       "allOf": [ { "$ref": "textureAccessor.schema.json" } ],
-      "description": "A description of the texture and channel to use for feature IDs. The `channels` property must have a single channel. Furthermore, feature IDs must be whole numbers in the range `[0, count - 1]` (inclusive), where `count` is the total number of features in the feature table. Texel values must be read as integers. Texture filtering should be disabled when fetching feature IDs."
+      "description": "A description of the texture and channel to use for feature IDs. The `channels` property must have a single channel. Furthermore, feature IDs must be whole numbers in the range `[0, count - 1]` (inclusive), where `count` is the total number of features in the feature table, or must equal `nullFeatureId` to indicate that no feature is assigned to this texel. Texel values must be read as integers. Texture filtering should be disabled when fetching feature IDs."
+    },
+    "nullFeatureId": {
+      "type": "number",
+      "description": "A value in the feature ID texture that indicates that no feature is assigned to this texel. Must be a whole number greater than or equal to `count`, where `count` is the total number of features in the feature table."
     },
     "extensions": {},
     "extras": {}


### PR DESCRIPTION
I was working on a tool that converted a labelled photogrammetry OBJ model to a glTF with feature ID textures when I noticed an omission in the spec - it's not possible to mark certain sections of a texture as not belonging to a feature. This makes it really difficult to handle textured models that are only partly labelled. What feature ID is used for the non-labelled areas?

This PR adds a new property called `nullFeatureId` which is the feature ID value that indicates "no feature here". It applies to anything that uses feature IDs. So you could have a section of the geometry that has no feature assigned to it, or a group of texels, or instances.

I considered not adding `nullFeatureId` and instead thought about adding a new rule that says any feature ID greater than `featureTable.count - 1` means the vertex/texel/instance is not assigned a feature. I was a little worried that this rule would be easily overlooked. Thoughts on this?