### PR TITLE
EXT_feature_metadata JSON schema cleanup

### DIFF
--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
@@ -71,6 +71,9 @@
         "number",
         "array"
       ],
+      "items": {
+        "type": "number"
+      },
       "description": "Maximum allowed values for property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values: they always correspond to the integer values."
     },
     "min": {
@@ -78,6 +81,9 @@
         "number",
         "array"
       ],
+      "items": {
+        "type": "number"
+      },
       "description": "Minimum allowed values for property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values: they always correspond to the integer values."
     },
     "default": {

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdAttribute.featureIds.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdAttribute.featureIds.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema",
-  "title": "Feature ID attribute",
+  "title": "Feature IDs",
   "type": "object",
   "description": "Feature IDs to be used as indices to property arrays in the feature table.",
   "properties": {

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/gltf.EXT_feature_metadata.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/gltf.EXT_feature_metadata.schema.json
@@ -35,11 +35,5 @@
     },
     "extensions": {},
     "extras": {}
-  },
-  "not": {
-    "required": [
-      "schema",
-      "schemaUri"
-    ]
   }
 }

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/statistics.class.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/statistics.class.property.schema.json
@@ -9,6 +9,9 @@
         "number",
         "array"
       ],
+      "items": {
+        "type": "number"
+      },
       "description": "The minimum property value. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values."
     },
     "max": {
@@ -16,6 +19,9 @@
         "number",
         "array"
       ],
+      "items": {
+        "type": "number"
+      },
       "description": "The maximum property value. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values."
     },
     "mean": {
@@ -23,6 +29,9 @@
         "number",
         "array"
       ],
+      "items": {
+        "type": "number"
+      },
       "description": "The arithmetic mean of the property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values."
     },
     "median": {
@@ -30,6 +39,9 @@
         "number",
         "array"
       ],
+      "items": {
+        "type": "number"
+      },
       "description": "The median of the property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values."
     },
     "standardDeviation": {
@@ -37,6 +49,9 @@
         "number",
         "array"
       ],
+      "items": {
+        "type": "number"
+      },
       "description": "The standard deviation of the property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values."
     },
     "variance": {
@@ -44,6 +59,9 @@
         "number",
         "array"
       ],
+      "items": {
+        "type": "number"
+      },
       "description": "The variance of the property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values."
     },
     "sum": {
@@ -51,6 +69,9 @@
         "number",
         "array"
       ],
+      "items": {
+        "type": "number"
+      },
       "description": "The sum of the property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values."
     },
     "occurrences": {
@@ -61,7 +82,10 @@
         "type": [
           "integer",
           "array"
-        ]
+        ],
+        "items": {
+          "type": "number"
+        }
       }
     },
     "extensions": {},


### PR DESCRIPTION
Includes @kring's commits from https://github.com/CesiumGS/glTF/pull/6 but rebased onto `3d-tiles-next` where the folder structure changed (see https://github.com/CesiumGS/glTF/pull/9#issuecomment-908769685 for details)