### PR TITLE
EXT_feature_metadata: Resolve 'type' / 'componentType' overlap, support VECN/MATN types

### DIFF
--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
@@ -26,7 +26,8 @@
         "MAT4",
         "ARRAY"
       ],
-      "description": "Element type represented by each property value. `ARRAY` is a fixed-length array when `componentCount` is defined and variable-length otherwise. Types `VECN` and `MATN` have implicit component counts of `N` and `N ⨉ N` respectively."
+      "default": "SINGLE",
+      "description": "Element type represented by each property value. `VECN` is a vector with `N` components. `MATN` is an `N ⨉ N` matrix. `ARRAY` is fixed-length when `componentCount` is defined, and is variable-length otherwise."
     },
     "enumType": {
       "type": "string",
@@ -53,7 +54,7 @@
     "componentCount": {
       "type": "integer",
       "minimum": 2,
-      "description": "Number of components per element for fixed-length `ARRAY` elements. Always undefined for variable-length `ARRAY` and other element types."
+      "description": "Number of components per element for fixed-length `ARRAY` elements. Always undefined for variable-length `ARRAY` and all other element types."
     },
     "normalized": {
       "type": "boolean",

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
@@ -17,26 +17,20 @@
     "type": {
       "type": "string",
       "enum": [
-        "INT8",
-        "UINT8",
-        "INT16",
-        "UINT16",
-        "INT32",
-        "UINT32",
-        "INT64",
-        "UINT64",
-        "FLOAT32",
-        "FLOAT64",
-        "BOOLEAN",
-        "STRING",
-        "ENUM",
+        "SINGLE",
+        "VEC2",
+        "VEC3",
+        "VEC4",
+        "MAT2",
+        "MAT3",
+        "MAT4",
         "ARRAY"
       ],
-      "description": "The property type. If `ENUM` is used, then `enumType` must also be specified. If `ARRAY` is used, then `componentType` must also be specified. `ARRAY` is a fixed-length array when `componentCount` is defined, and variable-length otherwise."
+      "description": "Element type represented by each property value. `ARRAY` is a fixed-length array when `componentCount` is defined and variable-length otherwise. Types `VECN` and `MATN` have implicit component counts of `N` and `N ⨉ N` respectively."
     },
     "enumType": {
       "type": "string",
-      "description": "An enum ID as declared in the `enums` dictionary. This value must be specified when `type` or `componentType` is `ENUM`."
+      "description": "Enum ID as declared in the `enums` dictionary. Required when `componentType` is `ENUM`."
     },
     "componentType": {
       "enum": [
@@ -54,12 +48,12 @@
         "STRING",
         "ENUM"
       ],
-      "description": "When `type` is `ARRAY` this indicates the type of each component of the array. If `ENUM` is used, then `enumType` must also be specified."
+      "description": "Data type of an element's components. When `type` is `SINGLE`, then `componentType` is also the data type of the element. When `componentType` is `ENUM`, `enumType` is required."
     },
     "componentCount": {
       "type": "integer",
       "minimum": 2,
-      "description": "The number of components per element for `ARRAY` elements."
+      "description": "Number of components per element for fixed-length `ARRAY` elements. Always undefined for variable-length `ARRAY` and other element types."
     },
     "normalized": {
       "type": "boolean",
@@ -110,13 +104,13 @@
   },
   "dependencies": {
     "componentCount": [
-      "componentType"
+      "type"
     ],
     "default": [
       "optional"
     ]
   },
   "required": [
-    "type"
+    "componentType"
   ]
 }


### PR DESCRIPTION
Implements option (E) from https://github.com/CesiumGS/3d-tiles-next/issues/152, which (if I've understood correctly) is where we ended up after the past two discussions.

Changes:
- `type` (optional) represents the element type: `SINGLE` | `VEC2` | `VEC3` | `ARRAY` | ...
- `componentType` (required) represents the data type of the element's components: `UINT8` | `UINT16` | ...
- `componentCount` is defined only for fixed-length `ARRAY`

There was also some discussion of renaming the `type`/`componentType` properties, since most properties are single-component elements using only `componentType`. I have no objection to renaming but haven't attempted it in this PR; the current terms map pretty closely to glTF terminology. If we did want to rename, here's a straw man suggestion:

- `type` → `elementType` (optional) `SINGLE` | `VEC2` | `VEC3` | `ARRAY` | ...
- `componentType` → `type` (required) `UINT8` | `UINT16` | ...

***

> **IMPORTANT:** Changes and renaming here will eventually affect the common schema definition for 3D Tiles, not just `EXT_feature_metadata` for glTF.

/cc @ptrgags @lilleyse