### PR TITLE
EXT_feature_metadata: Allow null feature IDs and noData property values

### DIFF
--- a/extensions/2.0/Vendor/EXT_feature_metadata/README.md
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/README.md
@@ -81,7 +81,7 @@ Features in a glTF primitive are identified in three ways:
 
 The most straightforward method for defining feature IDs is to store them in a glTF vertex attribute. Feature ID attributes must follow the naming convention `FEATURE_ID_X` where `X` is a non-negative integer. The first feature ID attribute is `FEATURE_ID_0`, the second `FEATURE_ID_1`, and so on.
 
-Feature IDs must be whole numbers in the range `[0, count - 1]` (inclusive), where `count` is the total number of features in the feature table.
+Feature IDs are whole numbers in the range `[0, count - 1]` (inclusive), where `count` is the total number of features in the feature table. Values outside this range may exist, indicating that no feature is associated.
 
 The attribute's accessor `type` must be `"SCALAR"` and `normalized` must be false. There is no restriction on `componentType`.
 
@@ -180,7 +180,7 @@ Often per-texel feature IDs provide finer granularity than per-vertex feature ID
 }
 ```
 
-The `featureId` entry for a feature ID texture extends the glTF [`textureInfo`](../../../../../specification/2.0/schema/textureInfo.schema.json) object. Each `channel` must be a positive integer corresponding to a channel of the source texture. Channels of an `RGBA` texture are numbered 0–3 respectively, although specialized texture formats may allow additional channels. Feature IDs must be whole numbers — stored in linear space — in the range `[0, count - 1]` (inclusive), where `count` is the total number of features in the feature table.
+The `featureId` entry for a feature ID texture extends the glTF [`textureInfo`](../../../../../specification/2.0/schema/textureInfo.schema.json) object. Each `channel` must be a non-negative integer corresponding to a channel of the source texture. Channels of an `RGBA` texture are numbered 0–3 respectively, although specialized texture formats may allow additional channels. Feature IDs are whole numbers in the range `[0, count - 1]` (inclusive), stored in linear space, where `count` is the total number of features in the feature table. Values outside this range may exist, indicating that no feature is associated.
 
 Texture filtering must be `9728` (NEAREST), or undefined, for any texture object referenced as a feature ID texture.
 

--- a/extensions/2.0/Vendor/EXT_feature_metadata/README.md
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/README.md
@@ -289,6 +289,8 @@ The schema and feature tables are defined in the root extension object in the gl
 
 `class` is the ID of the class in the schema. `count` is the number of features in the feature table, as well as the length of each property array. Property arrays are stored in glTF buffer views and use the binary encoding defined in the [Table Format](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/specification/Metadata#table-format) section of the [Cesium 3D Metadata Specification](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/specification/Metadata).
 
+As in the core glTF specification, values of NaN, +Infinity, and -Infinity are never allowed.
+
 Each buffer view `byteOffset` must be aligned to a multiple of 8 bytes.
 
 ### Feature Textures

--- a/extensions/2.0/Vendor/EXT_feature_metadata/README.md
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/README.md
@@ -237,7 +237,7 @@ Schemas may be given a `name`, `description`, and `version`.
 
 ### Feature Tables
 
-A feature table stores property values in a parallel array format. Each property array corresponds to a class property. The values contained within a property array must match the data type of the class property. Furthermore, the set of property arrays must match one-to-one with the class properties. There is one exception - if a property is optional the feature table may omit that property.
+A feature table stores property values in a parallel array format. Each property array corresponds to a class property. The values contained within a property array must match the data type of the class property. Furthermore, the set of property arrays must match one-to-one with the class properties. There is one exception - if a property specifies a `noData` value, the feature table may omit that property.
 
 The schema and feature tables are defined in the root extension object in the glTF model. See the example below:
 
@@ -293,7 +293,7 @@ Each buffer view `byteOffset` must be aligned to a multiple of 8 bytes.
 
 ### Feature Textures
 
-Feature textures (not to be confused with [Feature ID Textures](#feature-id-texture)) use textures rather than parallel arrays to store values. Feature textures are accessed directly by texture coordinates, rather than feature IDs. Feature textures are especially useful when texture mapping high frequency data to less detailed 3D surfaces.
+Feature textures (not to be confused with [Feature ID Textures](#feature-id-texture)) use textures rather than parallel arrays to store values. Feature textures are accessed directly by texture coordinates, rather than feature IDs. Feature textures are especially useful when texture mapping high frequency data to less detailed 3D surfaces. For each property that does not specify a `noData` value, a mapping to the corresponding texture channel or channels is required. Properties with a `noData` value are optional in feature textures instantiating a given class.
 
 Feature textures use the [Raster Format](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/specification/Metadata#raster-format) of the [Cesium 3D Metadata Specification](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/specification/Metadata) with a few additional constraints:
 

--- a/extensions/2.0/Vendor/EXT_feature_metadata/README.md
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/README.md
@@ -81,7 +81,7 @@ Features in a glTF primitive are identified in three ways:
 
 The most straightforward method for defining feature IDs is to store them in a glTF vertex attribute. Feature ID attributes must follow the naming convention `FEATURE_ID_X` where `X` is a non-negative integer. The first feature ID attribute is `FEATURE_ID_0`, the second `FEATURE_ID_1`, and so on.
 
-Feature IDs are whole numbers in the range `[0, count - 1]` (inclusive), where `count` is the total number of features in the feature table. Values outside this range may exist, indicating that no feature is associated.
+Feature IDs are whole numbers in the range `[0, count - 1]` (inclusive), where `count` is the total number of features in the feature table. Values outside this range indicate that no feature is associated.
 
 The attribute's accessor `type` must be `"SCALAR"` and `normalized` must be false. There is no restriction on `componentType`.
 
@@ -180,7 +180,7 @@ Often per-texel feature IDs provide finer granularity than per-vertex feature ID
 }
 ```
 
-The `featureId` entry for a feature ID texture extends the glTF [`textureInfo`](../../../../../specification/2.0/schema/textureInfo.schema.json) object. Each `channel` must be a non-negative integer corresponding to a channel of the source texture. Channels of an `RGBA` texture are numbered 0–3 respectively, although specialized texture formats may allow additional channels. Feature IDs are whole numbers in the range `[0, count - 1]` (inclusive), stored in linear space, where `count` is the total number of features in the feature table. Values outside this range may exist, indicating that no feature is associated.
+The `featureId` entry for a feature ID texture extends the glTF [`textureInfo`](../../../../../specification/2.0/schema/textureInfo.schema.json) object. Each `channel` must be a non-negative integer corresponding to a channel of the source texture. Channels of an `RGBA` texture are numbered 0–3 respectively, although specialized texture formats may allow additional channels. Feature IDs are whole numbers in the range `[0, count - 1]` (inclusive), stored in linear space, where `count` is the total number of features in the feature table. Values outside this range indicate that no feature is associated.
 
 Texture filtering must be `9728` (NEAREST), or undefined, for any texture object referenced as a feature ID texture.
 

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
@@ -82,7 +82,7 @@
         {"type": "array", "items": {"type": "number"}, "minItems": 1},
         {"type": "array", "items": {"type": "string"}, "minItems": 1}
       ],
-      "description": "NoData value represents missing data — also known as a sentinel value — wherever it appears. If omitted (excluding variable-length `ARRAY` properties), property values exist for all features, and the property is required in feature tables or textures instantiating the class. For variable-length `ARRAY` elements, NoData is implicitly `[]` and the property is never required; an additional NoData array, such as `[\"UNSPECIFIED\"]`, may be provided if necessary. `BOOLEAN` properties may not specify NoData values. `ENUM` NoData values must be a valid item name, not an integer value."
+      "description": "A `noData` value represents missing data — also known as a sentinel value — wherever it appears. If omitted (excluding variable-length `ARRAY` properties), property values exist for all features, and the property is required in feature tables or textures instantiating the class. For variable-length `ARRAY` elements, `noData` is implicitly `[]` and the property is never required; an additional `noData` array, such as `[\"UNSPECIFIED\"]`, may be provided if necessary. For fixed-length `ARRAY` properties, `noData` must be an array of length `componentCount`. For `VECN` properties, `noData` must be an array of length `N`. For `MATN` propperties, `noData` must be an array of length `N²`. `BOOLEAN` properties may not specify `noData` values. `ENUM` `noData` values must be a valid item name, not an integer value."
     },
     "semantic": {
       "type": "string",

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
@@ -82,7 +82,7 @@
         {"type": "array", "items": {"type": "number"}, "minItems": 1},
         {"type": "array", "items": {"type": "string"}, "minItems": 1}
       ],
-      "description": "NoData value represents missing data — also known as a sentinel value — wherever it appears. If omitted (excluding variable-length `ARRAY` properties), property values exist for all features, and the property is required in feature tables or textures instantiating the class. For variable-length `ARRAY` elements, NoData is implicitly `[]` and the property is never required; an additional NoData array, such as `[\"UNSPECIFIED\"]`, may be provided if necessary. `BOOLEAN` properties may not specify NoData values."
+      "description": "NoData value represents missing data — also known as a sentinel value — wherever it appears. If omitted (excluding variable-length `ARRAY` properties), property values exist for all features, and the property is required in feature tables or textures instantiating the class. For variable-length `ARRAY` elements, NoData is implicitly `[]` and the property is never required; an additional NoData array, such as `[\"UNSPECIFIED\"]`, may be provided if necessary. `BOOLEAN` properties may not specify NoData values. `ENUM` NoData values must be a valid item name, not an integer value."
     },
     "semantic": {
       "type": "string",

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
@@ -66,18 +66,18 @@
         {"type": "number"},
         {"type": "array", "items": {"type": "number"}, "minItems": 1}
       ],
-      "description": "Maximum allowed values for property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values: they always correspond to the integer values."
+      "description": "Maximum allowed value for the property. Only applicable for single-value numeric types, fixed-length arrays of numeric types, and `VECN` types. For single-value numeric types this is a single number. For fixed-length arrays and `VECN`, the maximum is an array with the same number of elements. The `normalized` property has no effect on the maximum, which always contains integer values."
     },
     "min": {
       "oneOf": [
         {"type": "number"},
         {"type": "array", "items": {"type": "number"}, "minItems": 1}
       ],
-      "description": "Minimum allowed values for property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values: they always correspond to the integer values."
+      "description": "Minimum allowed value for the property. Only applicable for single-value numeric types, fixed-length arrays of numeric types, and `VECN` types. For single-value numeric types this is a single number. For fixed-length arrays and `VECN`, the minimum is an array with the same number of elements. The `normalized` property has no effect on the minimum, which always contains integer values."
     },
     "required": {
       "type": "boolean",
-      "description": "If required, the property must be present for every feature of its class. If not required, individual features may include `noData` values, or the entire property may be omitted from a feature table or texture. As a result, `noData` has no effect on a required property. Client implementations may take advantage of required properties to make certain performance optimizations.",
+      "description": "If required, the property must be present for every feature of its class. If not required, individual features may include `noData` values, or the entire property may be omitted from a feature table or texture. As a result, `noData` has no effect on a required property. Client implementations may use required properties to make performance optimizations.",
       "default": false
     },
     "noData": {

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
@@ -75,6 +75,11 @@
       ],
       "description": "Minimum allowed values for property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values: they always correspond to the integer values."
     },
+    "required": {
+      "type": "boolean",
+      "description": "If required, the property must be present for every feature of its class. If not required, individual features may include `noData` values, or the entire property may be omitted from a feature table or texture. As a result, `noData` has no effect on a required property. Client implementations may take advantage of required properties to make certain performance optimizations.",
+      "default": false
+    },
     "noData": {
       "oneOf": [
         {"type": "number"},

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
@@ -62,38 +62,27 @@
       "default": false
     },
     "max": {
-      "type": [
-        "number",
-        "array"
+      "oneOf": [
+        {"type": "number"},
+        {"type": "array", "items": {"type": "number"}, "minItems": 1}
       ],
-      "items": {
-        "type": "number"
-      },
       "description": "Maximum allowed values for property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values: they always correspond to the integer values."
     },
     "min": {
-      "type": [
-        "number",
-        "array"
+      "oneOf": [
+        {"type": "number"},
+        {"type": "array", "items": {"type": "number"}, "minItems": 1}
       ],
-      "items": {
-        "type": "number"
-      },
       "description": "Minimum allowed values for property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values: they always correspond to the integer values."
     },
-    "default": {
-      "type": [
-        "boolean",
-        "number",
-        "string",
-        "array"
+    "noData": {
+      "oneOf": [
+        {"type": "number"},
+        {"type": "string"},
+        {"type": "array", "items": {"type": "number"}, "minItems": 1},
+        {"type": "array", "items": {"type": "string"}, "minItems": 1}
       ],
-      "description": "A default value to use when the property value is not defined. If used, `optional` must be set to true. The type of the default value must match the property definition: For `BOOLEAN` use `true` or `false`. For `STRING` use a JSON string. For a numeric type use a JSON number. For `ENUM` use the enum `name`, not the integer value. For `ARRAY` use a JSON array containing values matching the `componentType`."
-    },
-    "optional": {
-      "type": "boolean",
-      "description": "If true, this property is optional.",
-      "default": false
+      "description": "NoData value represents missing data — also known as a sentinel value — wherever it appears. If omitted (excluding variable-length `ARRAY` properties), property values exist for all features, and the property is required in feature tables or textures instantiating the class. For variable-length `ARRAY` elements, NoData is implicitly `[]` and the property is never required; an additional NoData array, such as `[\"UNSPECIFIED\"]`, may be provided if necessary. `BOOLEAN` properties may not specify NoData values."
     },
     "semantic": {
       "type": "string",
@@ -106,9 +95,6 @@
   "dependencies": {
     "componentCount": [
       "type"
-    ],
-    "default": [
-      "optional"
     ]
   },
   "required": [


### PR DESCRIPTION
From discussion in https://github.com/CesiumGS/glTF/pull/8. 

Changes:

- Feature ID attributes and textures may specify values outside `[0, count - 1]` to indicate no feature is associated with the vertex, instance, or texel.
- Properties may specify a `noData` value ("sentinel value") to be treated as missing data.
- Removed `optional` and `default` from Property definition.
- Disallow `NaN`.

Questions:

- I don't think anything we've discussed allows nullable texels in feature property textures, ... that could be OK, since feature ID textures and a feature table could be used for these cases. Or do we need something like a `noData` texel value here?
- Note the particular language around variable-length arrays and `noData` values.

/cc @ptrgags @lilleyse 