### PR TITLE
EXT_feature_metadata: featureTables/featureTextures → propertyTables/propertyTextures

### DIFF
--- a/extensions/2.0/Vendor/EXT_feature_metadata/README.md
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/README.md
@@ -49,7 +49,7 @@ This extension is optional, meaning it should be placed in the `extensionsUsed` 
 
 ## Overview
 
-A **feature** is an entity that has both geometry and non-geometric properties. In Geographic Information Systems (GIS) a feature is an entity such as a point, polyline, or polygon that represents some element on a map. In another domain like CAD/BIM a feature might be a component of a design model. A feature could also be a 3D building in a city, a tree in a forest, a sample point in a weather model, or a patch of texels on a 3D model.
+A **feature** is an entity that has both geometry and associated properties. In Geographic Information Systems (GIS) a feature is an entity such as a point, polyline, or polygon that represents some element on a map. In another domain like CAD/BIM a feature might be a component of a design model. A feature could also be a 3D building in a city, a tree in a forest, a sample point in a weather model, or a patch of texels on a 3D model.
 
 This extension allows batching features for efficient streaming to a client for rendering and interaction. Efficiency comes from transferring multiple features in the same glTF and rendering them in the least number of draw calls necessary.
 
@@ -295,7 +295,7 @@ Each buffer view `byteOffset` must be aligned to a multiple of 8 bytes.
 
 ### Property Textures
 
-Property textures (not to be confused with [Feature ID Textures](#feature-id-texture)) use textures rather than parallel arrays to store values. Property textures are accessed directly by texture coordinates, rather than feature IDs. Property textures are especially useful when texture mapping high frequency data to less detailed 3D surfaces. For each property that does not specify a `noData` value, a mapping to the corresponding texture channel or channels is required. Properties with a `noData` value are optional in property textures instantiating a given class.
+Property textures use textures rather than parallel arrays to store values. Property textures are accessed directly by texture coordinates, and do not require feature IDs. Property textures are especially useful when texture mapping high frequency data to less detailed 3D surfaces. For each property that does not specify a `noData` value, a mapping to the corresponding texture channel or channels is required. Properties with a `noData` value are optional in property textures instantiating a given class.
 
 Property textures use the [Raster Format](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/specification/Metadata#raster-format) of the [Cesium 3D Metadata Specification](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/specification/Metadata) with a few additional constraints:
 

--- a/extensions/2.0/Vendor/EXT_feature_metadata/README.md
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/README.md
@@ -38,10 +38,10 @@ This extension is optional, meaning it should be placed in the `extensionsUsed` 
     - [Implicit Feature IDs](#implicit-feature-ids)
   - [Feature ID Textures](#feature-id-textures)
   - [Feature ID Instance Attributes](#feature-id-instance-attributes)
-- [Feature Metadata](#feature-metadata)
+- [Feature Properties](#feature-properties)
   - [Schemas](#schemas)
-  - [Feature Tables](#feature-tables)
-  - [Feature Textures](#feature-textures)
+  - [Property Tables](#property-tables)
+  - [Property Textures](#property-textures)
 - [Binary Data Storage](#binary-data-storage)
 - [Examples](#examples)
 - [Schema](#schema)
@@ -49,19 +49,19 @@ This extension is optional, meaning it should be placed in the `extensionsUsed` 
 
 ## Overview
 
-A **feature** is an entity that has both geometry and metadata. In Geographic Information Systems (GIS) a feature is an entity such as a point, polyline, or polygon that represents some element on a map. In another domain like CAD/BIM a feature might be a component of a design model. A feature could also be a 3D building in a city, a tree in a forest, a sample point in a weather model, or a patch of texels on a 3D model.
+A **feature** is an entity that has both geometry and non-geometric properties. In Geographic Information Systems (GIS) a feature is an entity such as a point, polyline, or polygon that represents some element on a map. In another domain like CAD/BIM a feature might be a component of a design model. A feature could also be a 3D building in a city, a tree in a forest, a sample point in a weather model, or a patch of texels on a 3D model.
 
 This extension allows batching features for efficient streaming to a client for rendering and interaction. Efficiency comes from transferring multiple features in the same glTF and rendering them in the least number of draw calls necessary.
 
 Feature IDs enable individual features to be identified and updated at runtime. For example, a selected feature could be shown/hidden, or highlighted a different color. Feature IDs may be assigned on a per-vertex, per-texel, or per-instance basis.
 
-Feature IDs may be used to access metadata, such as passing a building's ID to get its address. Feature metadata is stored in a compact binary tabular format described in the [Cesium 3D Metadata Specification](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/specification/Metadata).
+Feature IDs may be used to access associated properties, such as passing a building's ID to get its address. Feature properties are stored in a compact binary tabular format described in the [Cesium 3D Metadata Specification](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/specification/Metadata).
 
 ![Building Example](figures/feature-table-buildings.png)
 
-In the image above, a glTF consists of two houses batched together into a single primitive. A feature ID attribute on the primitive indicates that all of the vertices making up the first house have a feature ID of 0, while all vertices making up the second house have the feature ID 1. The feature ID is then used to access the building's metadata from the feature table.
+In the image above, a glTF consists of two houses batched together into a single primitive. A feature ID attribute on the primitive indicates that all of the vertices making up the first house have a feature ID of 0, while all vertices making up the second house have the feature ID 1. The feature ID is then used to access the building's properties from the property table.
 
-Feature metadata may also be stored directly in textures. This is especially useful when texture mapping high frequency data, such as material properties, to less detailed 3D surfaces. Feature textures enable new styling and analytics capabilities, and complement glTF PBR textures.
+Feature properties may also be stored directly in textures. This is especially useful when texture mapping high frequency data, such as material properties, to less detailed 3D surfaces. Property textures enable new styling and analytics capabilities, and complement glTF PBR textures.
 
 See [Examples](#examples) for a full list of use cases for this extension.
 
@@ -81,13 +81,13 @@ Features in a glTF primitive are identified in three ways:
 
 The most straightforward method for defining feature IDs is to store them in a glTF vertex attribute. Feature ID attributes must follow the naming convention `FEATURE_ID_X` where `X` is a non-negative integer. The first feature ID attribute is `FEATURE_ID_0`, the second `FEATURE_ID_1`, and so on.
 
-Feature IDs are whole numbers in the range `[0, count - 1]` (inclusive), where `count` is the total number of features in the feature table. Values outside this range indicate that no feature is associated.
+Feature IDs are whole numbers in the range `[0, count - 1]` (inclusive), where `count` is the total number of features in the property table. Values outside this range indicate that no feature is associated.
 
 The attribute's accessor `type` must be `"SCALAR"` and `normalized` must be false. There is no restriction on `componentType`.
 
 > **Implementation Note:** since glTF accessors do not support `UNSIGNED_INT` types for 32-bit integers, `FLOAT` may be used instead. This allows for integer feature IDs up to 2²⁴. For smaller ranges of feature IDs, `UNSIGNED_BYTE` or `UNSIGNED_SHORT` can still be used. Note that this requires aligning each feature ID to 4-byte boundaries to adhere to glTF's alignment rules.
 
-![Feature Table](figures/feature-table.png)
+![Property Table](figures/feature-table.png)
 
 ```jsonc
 {
@@ -101,7 +101,7 @@ The attribute's accessor `type` must be `"SCALAR"` and `normalized` must be fals
       "mode": 4,
       "extensions": {
         "EXT_feature_metadata": {
-          "featureTables": [0],
+          "propertyTables": [0],
           "featureIds": [{"attribute": 0}]
         }
       }
@@ -141,7 +141,7 @@ For example
       "mode": 0,
       "extensions": {
         "EXT_feature_metadata": {
-          "featureTables": [0],
+          "propertyTables": [0],
           "featureIds": [{"offset": 0, "repeat": 1}]
         }
       }
@@ -169,7 +169,7 @@ Often per-texel feature IDs provide finer granularity than per-vertex feature ID
       "material": 0,
       "extensions": {
         "EXT_feature_metadata": {
-          "featureTables": [0],
+          "propertyTables": [0],
           "featureIds": [
             {"index": 0, "texCoord": 0, "channel": 0}
           ]
@@ -180,7 +180,7 @@ Often per-texel feature IDs provide finer granularity than per-vertex feature ID
 }
 ```
 
-The `featureId` entry for a feature ID texture extends the glTF [`textureInfo`](../../../../../specification/2.0/schema/textureInfo.schema.json) object. Each `channel` must be a non-negative integer corresponding to a channel of the source texture. Channels of an `RGBA` texture are numbered 0–3 respectively, although specialized texture formats may allow additional channels. Feature IDs are whole numbers in the range `[0, count - 1]` (inclusive), stored in linear space, where `count` is the total number of features in the feature table. Values outside this range indicate that no feature is associated.
+The `featureId` entry for a feature ID texture extends the glTF [`textureInfo`](../../../../../specification/2.0/schema/textureInfo.schema.json) object. Each `channel` must be a non-negative integer corresponding to a channel of the source texture. Channels of an `RGBA` texture are numbered 0–3 respectively, although specialized texture formats may allow additional channels. Feature IDs are whole numbers in the range `[0, count - 1]` (inclusive), stored in linear space, where `count` is the total number of features in the property table. Values outside this range indicate that no feature is associated.
 
 Texture filtering must be `9728` (NEAREST), or undefined, for any texture object referenced as a feature ID texture.
 
@@ -203,7 +203,7 @@ Feature IDs may also be assigned to individual instances when using the [`EXT_me
           },
         },
         "EXT_feature_metadata": {
-          "featureTables": [0],
+          "propertyTables": [0],
           "featureIds": [{"attribute": 0}]
         }
       }
@@ -212,11 +212,11 @@ Feature IDs may also be assigned to individual instances when using the [`EXT_me
 }
 ```
 
-## Feature Metadata
+## Feature Properties
 
-Feature metadata is structured according to a **schema**. A schema has a set of **classes** and **enums**. A class contains a set of **properties**, which may be numeric, boolean, string, enum, or array types.
+Feature properties are structured according to a **schema**. A schema has a set of **classes** and **enums**. A class contains a set of **properties**, which may be numeric, boolean, string, enum, or array types.
 
-A **feature** is a specific instantiation of class containing **property values**. Property values are stored in either a **feature table** or a **feature texture** depending on the use case. Both formats are designed for storing property values for a large number of features.
+A **feature** is a specific instantiation of class containing **property values**. Property values are stored in either a **property table** or a **property texture** depending on the use case. Both formats are designed for storing property values for a large number of features.
 
 By default, properties do not have any inherent meaning. A property may be assigned a **semantic**, an identifier that describes how the property should be interpreted. Built-in semantics include `ID` and `NAME`, as defined below.
 
@@ -235,11 +235,11 @@ A schema may be embedded in the extension directly or referenced externally with
 
 Schemas may be given a `name`, `description`, and `version`.
 
-### Feature Tables
+### Property Tables
 
-A feature table stores property values in a parallel array format. Each property array corresponds to a class property. The values contained within a property array must match the data type of the class property. Furthermore, the set of property arrays must match one-to-one with the class properties. There is one exception - if a property specifies a `noData` value, the feature table may omit that property.
+A property table stores property values in a parallel array format. Each property array corresponds to a class property. The values contained within a property array must match the data type of the class property. Furthermore, the set of property arrays must match one-to-one with the class properties. There is one exception - if a property specifies a `noData` value, the property table may omit that property.
 
-The schema and feature tables are defined in the root extension object in the glTF model. See the example below:
+The schema and property tables are defined in the root extension object in the glTF model. See the example below:
 
 ```jsonc
 {
@@ -265,7 +265,7 @@ The schema and feature tables are defined in the root extension object in the gl
           }
         }
       },
-      "featureTables": [{
+      "propertyTables": [{
         "name": "tree",
         "class": "tree",
         "count": 10,
@@ -287,17 +287,17 @@ The schema and feature tables are defined in the root extension object in the gl
 }
 ```
 
-`class` is the ID of the class in the schema. `count` is the number of features in the feature table, as well as the length of each property array. Property arrays are stored in glTF buffer views and use the binary encoding defined in the [Table Format](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/specification/Metadata#table-format) section of the [Cesium 3D Metadata Specification](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/specification/Metadata).
+`class` is the ID of the class in the schema. `count` is the number of features in the property table, as well as the length of each property array. Property arrays are stored in glTF buffer views and use the binary encoding defined in the [Table Format](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/specification/Metadata#table-format) section of the [Cesium 3D Metadata Specification](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/specification/Metadata).
 
 As in the core glTF specification, values of NaN, +Infinity, and -Infinity are never allowed.
 
 Each buffer view `byteOffset` must be aligned to a multiple of 8 bytes.
 
-### Feature Textures
+### Property Textures
 
-Feature textures (not to be confused with [Feature ID Textures](#feature-id-texture)) use textures rather than parallel arrays to store values. Feature textures are accessed directly by texture coordinates, rather than feature IDs. Feature textures are especially useful when texture mapping high frequency data to less detailed 3D surfaces. For each property that does not specify a `noData` value, a mapping to the corresponding texture channel or channels is required. Properties with a `noData` value are optional in feature textures instantiating a given class.
+Property textures (not to be confused with [Feature ID Textures](#feature-id-texture)) use textures rather than parallel arrays to store values. Property textures are accessed directly by texture coordinates, rather than feature IDs. Property textures are especially useful when texture mapping high frequency data to less detailed 3D surfaces. For each property that does not specify a `noData` value, a mapping to the corresponding texture channel or channels is required. Properties with a `noData` value are optional in property textures instantiating a given class.
 
-Feature textures use the [Raster Format](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/specification/Metadata#raster-format) of the [Cesium 3D Metadata Specification](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/specification/Metadata) with a few additional constraints:
+Property textures use the [Raster Format](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/specification/Metadata#raster-format) of the [Cesium 3D Metadata Specification](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/specification/Metadata) with a few additional constraints:
 
 * A scalar property cannot be encoded into multiple channels. For example, it is not possible to encode a `UINT32` property in an `RGBA8` texture.
 * Components of fixed-length array properties must be separate channels within the same texture.
@@ -305,14 +305,14 @@ Feature textures use the [Raster Format](https://github.com/CesiumGS/3d-tiles/tr
 
 Additionally, the data type and bit depth of the image must be compatible with the property type. An 8-bit per pixel RGB image is only compatible with `UINT8` or normalized `UINT8` properties, and array properties thereof with three components or less. Likewise, a floating point property requires a floating point-compatible image format like KTX2 which may require additional extensions.
 
-Feature textures are defined with the following steps:
+Property textures are defined with the following steps:
 
-1. A class is defined in the root `EXT_feature_metadata` extension object. This is used to describe the metadata in the texture.
-2. A feature texture is defined in the root `EXT_feature_metadata.featureTextures` object. This must reference the class ID defined in step 1.
-3. A feature texture is associated with a primitive by listing the feature texture ID in the `primitive.EXT_feature_metadata.featureTextures` array.
-<img src="figures/feature-texture.png"  alt="Feature Texture" width="500">
+1. A class is defined in the root `EXT_feature_metadata` extension object. This is used to describe the properties in the texture.
+2. A property texture is defined in the root `EXT_feature_metadata.propertyTextures` object. This must reference the class ID defined in step 1.
+3. A property texture is associated with a primitive by listing the property texture ID in the `primitive.EXT_feature_metadata.propertyTextures` array.
+<img src="figures/feature-texture.png"  alt="Property Texture" width="500">
 
-_Class and feature texture_
+_Class and property texture_
 
 ```jsonc
 {
@@ -334,7 +334,7 @@ _Class and feature texture_
           }
         }
       },
-      "featureTextures": [{
+      "propertyTextures": [{
         "class": "heatSample",
         "index": 0,
         "texCoord": 0,
@@ -362,7 +362,7 @@ _Primitive_
       "material": 0,
       "extensions": {
         "EXT_feature_metadata": {
-          "featureTextures": [0]
+          "propertyTextures": [0]
         }
       }
     }
@@ -371,9 +371,9 @@ _Primitive_
 ```
 
 
-A `featureTexture` object extends the glTF [`textureInfo`](../../../../../specification/2.0/schema/textureInfo.schema.json) object. `texCoord` refers to the texture coordinate set of the referring primitive. The `properties` map specifies the texture channels providing data for all required class properties, and perhaps optional class properties. An array of integer index values identify channels, where multiple channels may be used only for fixed-length arrays of 2, 3, or 4 components. Channels of an `RGBA` texture are numbered 0–3 respectively, although specialized texture formats may allow additional channels. All values are stored in linear space.
+A `propertyTexture` object extends the glTF [`textureInfo`](../../../../../specification/2.0/schema/textureInfo.schema.json) object. `texCoord` refers to the texture coordinate set of the referring primitive. The `properties` map specifies the texture channels providing data for all required class properties, and perhaps optional class properties. An array of integer index values identify channels, where multiple channels may be used only for fixed-length arrays of 2, 3, or 4 components. Channels of an `RGBA` texture are numbered 0–3 respectively, although specialized texture formats may allow additional channels. All values are stored in linear space.
 
-Texture filtering must be `9728` (NEAREST), `9729` (LINEAR), or undefined, for any texture object referenced as a feature texture.
+Texture filtering must be `9728` (NEAREST), `9729` (LINEAR), or undefined, for any texture object referenced as a property texture.
 
 ## Binary Data Storage
 
@@ -393,14 +393,14 @@ The examples below shows the breadth of possible use cases for this extension.
 Example|Description|Image
 --|--|--
 Triangle mesh|Feature IDs are assigned to each vertex to distinguish components of a building.|![Building Components](figures/building-components.png)
-Per-vertex metadata<img width=700/>|An implicit feature ID is assigned to each vertex. The feature table stores `FLOAT64` accuracy values. |![Per-vertex metadata](figures/per-vertex-metadata.png)
-Per-triangle metadata|An implicit feature ID is assigned to each set of three vertices. The feature table stores `FLOAT64` area values.|![Per-triangle metadata](figures/per-triangle-metadata.png)
-Per-point metadata|An implicit feature ID is assigned to each point. The feature table stores `FLOAT64` , `STRING`, and `ENUM` properties, which are not possible through glTF vertex attribute accessors alone.|![Point features](figures/point-features.png)
+Per-vertex metadata<img width=700/>|An implicit feature ID is assigned to each vertex. The property table stores `FLOAT64` accuracy values. |![Per-vertex metadata](figures/per-vertex-metadata.png)
+Per-triangle metadata|An implicit feature ID is assigned to each set of three vertices. The property table stores `FLOAT64` area values.|![Per-triangle metadata](figures/per-triangle-metadata.png)
+Per-point metadata|An implicit feature ID is assigned to each point. The property table stores `FLOAT64` , `STRING`, and `ENUM` properties, which are not possible through glTF vertex attribute accessors alone.|![Point features](figures/point-features.png)
 Per-node metadata|Vertices in node 0 and node 1, not batched together, are assigned different `offset` feature IDs.|![Per-node metadata](figures/per-node-metadata.png)
-Multi-point features|A point cloud with two feature tables, one storing metadata for groups of points and the other storing metadata for individual points.|![Multi-point features](figures/point-cloud-layers.png)
-Multi-instance features|Instanced tree models where trees are assigned to groups with a per-instance feature ID attribute. One feature table stores per-group metadata and the other stores per-tree metadata.|![Multi-instance features](figures/multi-instance-metadata.png)
-Material classification|A textured mesh using a feature texture to store both material enums and normalized `UINT8` thermal temperatures.|![Material Classification](figures/material-classification.png)
-Composite|A glTF containing a 3D mesh (house), a point cloud (tree), and instanced models (fencing) with three feature tables.|![Composite Example](figures/composite-example.png)
+Multi-point features|A point cloud with two property tables, one storing metadata for groups of points and the other storing metadata for individual points.|![Multi-point features](figures/point-cloud-layers.png)
+Multi-instance features|Instanced tree models where trees are assigned to groups with a per-instance feature ID attribute. One property table stores per-group metadata and the other stores per-tree metadata.|![Multi-instance features](figures/multi-instance-metadata.png)
+Material classification|A textured mesh using a property texture to store both material enums and normalized `UINT8` thermal temperatures.|![Material Classification](figures/material-classification.png)
+Composite|A glTF containing a 3D mesh (house), a point cloud (tree), and instanced models (fencing) with three property tables.|![Composite Example](figures/composite-example.png)
 
 ## Schema
 
@@ -418,7 +418,7 @@ Composite|A glTF containing a 3D mesh (house), a point cloud (tree), and instanc
     * Removed `BLOB` type
     * Added `ENUM` to the list of supported types and component types and added `enumType` to refer to the chosen enum
     * `min` and `max` are now numbers instead of single-element arrays for non-`ARRAY` properties
-  * Changes to feature table
+  * Changes to property table
     * Removed `offsetBufferViews`, replaced with `arrayOffsetBufferView` and `stringOffsetBufferView`
     * Removed `blobByteLength`
     * Removed `stringByteLength`
@@ -437,5 +437,6 @@ Composite|A glTF containing a 3D mesh (house), a point cloud (tree), and instanc
 * **Version 2.0.0** September 2021
   * Renamed `constant` to `offset`, and `divisor` to `repeat`
   * Removed `statistics` specification, to be considered as a future extension
-  * Removed `featureIdAttributes` and `featureIdTextures`, replaced with `featureIds` and `featureTables`.
-  * Removed string ID references to feature tables and textures, replaced with integer IDs.
+  * Renamed `featureTable` → `propertyTable` and `featureTexture` → `propertyTexture`
+  * Removed `featureIdAttributes` and `featureIdTextures`, replaced with `featureIds`
+  * Removed string ID references to property tables and textures, replaced with integer IDs

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
@@ -77,7 +77,7 @@
     },
     "required": {
       "type": "boolean",
-      "description": "If required, the property must be present for every feature of its class. If not required, individual features may include `noData` values, or the entire property may be omitted from a feature table or texture. As a result, `noData` has no effect on a required property. Client implementations may use required properties to make performance optimizations.",
+      "description": "If required, the property must be present for every feature of its class. If not required, individual features may include `noData` values, or the entire property may be omitted from a property table or texture. As a result, `noData` has no effect on a required property. Client implementations may use required properties to make performance optimizations.",
       "default": false
     },
     "noData": {
@@ -87,7 +87,7 @@
         {"type": "array", "items": {"type": "number"}, "minItems": 1},
         {"type": "array", "items": {"type": "string"}, "minItems": 1}
       ],
-      "description": "A `noData` value represents missing data — also known as a sentinel value — wherever it appears. If omitted (excluding variable-length `ARRAY` properties), property values exist for all features, and the property is required in feature tables or textures instantiating the class. For variable-length `ARRAY` elements, `noData` is implicitly `[]` and the property is never required; an additional `noData` array, such as `[\"UNSPECIFIED\"]`, may be provided if necessary. For fixed-length `ARRAY` properties, `noData` must be an array of length `componentCount`. For `VECN` properties, `noData` must be an array of length `N`. For `MATN` propperties, `noData` must be an array of length `N²`. `BOOLEAN` properties may not specify `noData` values. `ENUM` `noData` values must be a valid item name, not an integer value."
+      "description": "A `noData` value represents missing data — also known as a sentinel value — wherever it appears. If omitted (excluding variable-length `ARRAY` properties), property values exist for all features, and the property is required in property tables or textures instantiating the class. For variable-length `ARRAY` elements, `noData` is implicitly `[]` and the property is never required; an additional `noData` array, such as `[\"UNSPECIFIED\"]`, may be provided if necessary. For fixed-length `ARRAY` properties, `noData` must be an array of length `componentCount`. For `VECN` properties, `noData` must be an array of length `N`. For `MATN` propperties, `noData` must be an array of length `N²`. `BOOLEAN` properties may not specify `noData` values. `ENUM` `noData` values must be a valid item name, not an integer value."
     },
     "semantic": {
       "type": "string",

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdAttribute.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdAttribute.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema",
   "title": "Feature IDs",
   "type": "object",
-  "description": "Feature IDs to be used as indices to property arrays in the feature table.",
+  "description": "Feature IDs to be used as indices to property arrays in the property table.",
   "properties": {
     "attribute": {
       "type": "string",

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdTexture.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdTexture.schema.json
@@ -7,9 +7,9 @@
   "properties": {
     "index": { },
     "texCoord": { },
-    "featureTable": {
+    "propertyTable": {
       "type": "string",
-      "description": "The ID of the feature table in the model's root `EXT_feature_metadata.featureTables` dictionary."
+      "description": "The ID of the property table in the model's root `EXT_feature_metadata.propertyTables` dictionary."
     },
     "channel": {
       "type": "integer",
@@ -20,7 +20,7 @@
     "extras": {}
   },
   "required": [
-    "featureTable",
+    "propertyTable",
     "channel"
   ]
 }

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/gltf.EXT_feature_metadata.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/gltf.EXT_feature_metadata.schema.json
@@ -13,20 +13,20 @@
       "description": "A uri to an external schema file.",
       "format": "uriref"
     },
-    "featureTables": {
+    "propertyTables": {
       "type": "object",
-      "description": "A dictionary, where each key is a feature table ID and each value is an object defining the feature table.",
+      "description": "A dictionary, where each key is a property table ID and each value is an object defining the property table.",
       "minProperties": 1,
       "additionalProperties": {
-        "$ref": "featureTable.schema.json"
+        "$ref": "propertyTable.schema.json"
       }
     },
-    "featureTextures": {
+    "propertyTextures": {
       "type": "object",
-      "description": "A dictionary, where each key is a feature texture ID and each value is an object defining the feature texture.",
+      "description": "A dictionary, where each key is a property texture ID and each value is an object defining the property texture.",
       "minProperties": 1,
       "additionalProperties": {
-        "$ref": "featureTexture.schema.json"
+        "$ref": "propertyTexture.schema.json"
       }
     },
     "extensions": {},

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/node.EXT_feature_metadata.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/node.EXT_feature_metadata.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema",
   "title": "EXT_feature_metadata extension for EXT_mesh_gpu_instancing",
   "type": "object",
-  "description": "An object describing per-instance feature IDs to be used as indices to property arrays in the feature table.",
+  "description": "An object describing per-instance feature IDs to be used as indices to property arrays in the property table.",
   "properties": {
     "featureIds": {
       "type": "array",
@@ -10,9 +10,9 @@
       "items": {"$ref": "featureIdAttribute.schema.json"},
       "minItems": 1
     },
-    "featureTables": {
+    "propertyTables": {
       "type": "array",
-      "description": "An array of IDs of feature tables from the root `EXT_feature_metadata` object.",
+      "description": "An array of IDs of property tables from the root `EXT_feature_metadata` object.",
       "items": {
         "allOf": [ {"$ref": "glTFid.schema.json" } ]
       },

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/primitive.EXT_feature_metadata.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/primitive.EXT_feature_metadata.schema.json
@@ -15,17 +15,17 @@
       },
       "minItems": 1
     },
-    "featureTables": {
+    "propertyTables": {
       "type": "array",
-      "description": "An array of IDs of feature tables from the root `EXT_feature_metadata` object.",
+      "description": "An array of IDs of property tables from the root `EXT_feature_metadata` object.",
       "items": {
         "allOf": [ {"$ref": "glTFid.schema.json" } ]
       },
       "minItems": 1
     },
-    "featureTextures": {
+    "propertyTextures": {
       "type": "array",
-      "description": "An array of IDs of feature textures from the root `EXT_feature_metadata` object.",
+      "description": "An array of IDs of property textures from the root `EXT_feature_metadata` object.",
       "items": {
         "allOf": [ {"$ref": "glTFid.schema.json" } ]
       },
@@ -38,12 +38,12 @@
     {
       "required": [
         "featureIds",
-        "featureTables"
+        "propertyTables"
       ]
     },
     {
       "required": [
-        "featureTextures"
+        "propertyTextures"
       ]
     }
   ]

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/propertyTable.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/propertyTable.property.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema",
-  "title": "Feature Table Property",
+  "title": "Property Table Property",
   "type": "object",
   "description": "An array of binary property values.",
   "properties": {
@@ -21,7 +21,7 @@
     },
     "arrayOffsetBufferView": {
       "allOf": [ { "$ref": "glTFid.schema.json" } ],
-      "description": "The index of the buffer view containing offsets for variable-length arrays. The number of offsets is equal to the feature table `count` plus one. The offsets represent the start positions of each array, with the last offset representing the position after the last array. The array length is computed using the difference between the current offset and the subsequent offset. If `componentType` is `STRING` the offsets index into the string offsets array (stored in `stringOffsetBufferView`), otherwise they index into the property array (stored in `bufferView`). The data type of these offsets is determined by `offsetType`. The buffer view `byteOffset` must be aligned to a multiple of 8 bytes in the same manner as the main `bufferView`"
+      "description": "The index of the buffer view containing offsets for variable-length arrays. The number of offsets is equal to the property table `count` plus one. The offsets represent the start positions of each array, with the last offset representing the position after the last array. The array length is computed using the difference between the current offset and the subsequent offset. If `componentType` is `STRING` the offsets index into the string offsets array (stored in `stringOffsetBufferView`), otherwise they index into the property array (stored in `bufferView`). The data type of these offsets is determined by `offsetType`. The buffer view `byteOffset` must be aligned to a multiple of 8 bytes in the same manner as the main `bufferView`"
     },
     "stringOffsetBufferView": {
       "allOf": [ { "$ref": "glTFid.schema.json" } ],

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/propertyTable.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/propertyTable.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema",
   "title": "Property Table",
   "type": "object",
-  "description": "A property table defined by a class and property values stored in arrays.",
+  "description": "Features conforming to a class, organized as property values stored in columnar arrays.",
   "properties": {
     "class": {
       "type": "string",

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/propertyTable.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/propertyTable.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema",
-  "title": "Feature Table",
+  "title": "Property Table",
   "type": "object",
-  "description": "A feature table defined by a class and property values stored in arrays.",
+  "description": "A property table defined by a class and property values stored in arrays.",
   "properties": {
     "class": {
       "type": "string",
@@ -18,7 +18,7 @@
       "description": "A dictionary, where each key corresponds to a property ID in the class' `properties` dictionary and each value is an object describing where property values are stored. Optional properties may be excluded from this dictionary.",
       "minProperties": 1,
       "additionalProperties": {
-        "$ref": "featureTable.property.schema.json"
+        "$ref": "propertyTable.property.schema.json"
       }
     },
     "extensions": {},

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/propertyTexture.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/propertyTexture.schema.json
@@ -3,7 +3,7 @@
   "title": "Property Texture",
   "type": "object",
   "allOf": [ { "$ref": "textureInfo.schema.json" } ],
-  "description": "Features whose property values are stored directly in texture channels. This is not to be confused with feature ID textures which store feature IDs for use with a property table.",
+  "description": "Features conforming to a class, organized as property values stored in texture channels.",
   "properties": {
     "index": { },
     "texCoord": { },

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/propertyTexture.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/propertyTexture.schema.json
@@ -1,15 +1,15 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema",
-  "title": "Feature Texture",
+  "title": "Property Texture",
   "type": "object",
   "allOf": [ { "$ref": "textureInfo.schema.json" } ],
-  "description": "Features whose property values are stored directly in texture channels. This is not to be confused with feature ID textures which store feature IDs for use with a feature table.",
+  "description": "Features whose property values are stored directly in texture channels. This is not to be confused with feature ID textures which store feature IDs for use with a property table.",
   "properties": {
     "index": { },
     "texCoord": { },
     "class": {
       "type": "string",
-      "description": "The class this feature texture conforms to. The value must be a class ID declared in the `classes` dictionary."
+      "description": "The class this property texture conforms to. The value must be a class ID declared in the `classes` dictionary."
     },
     "properties": {
       "type": "object",


### PR DESCRIPTION
Renames:

- `featureTable` → `propertyTable`
- `featureTexture` → `propertyTexture`

I've also attempted to use the term "properties" instead of "metadata" in a few cases, but may have a few more to clean up in the language/clarity pass.

We've discussed perhaps renaming the extension from `EXT_feature_metadata`. Also see https://github.com/CesiumGS/glTF/pull/4/#discussion_r588873765. The nearest extension in the glTF specification is [`EXT_mesh_gpu_instancing`](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/EXT_mesh_gpu_instancing), for reference. Ideas, in no particular order:

- `EXT_mesh_batching`
- `EXT_mesh_feature_batching`
- `EXT_mesh_properties`
- `EXT_feature_properties`
- `EXT_mesh_features`
- ... ?

If we do want to rename I'll do that update in a separate PR, but it does relate a bit to the wording used in this change. /cc @ptrgags @lilleyse 
