### PR TITLE
EXT_feature_metadata: Restrictions on string IDs, add property table and texture names

### DIFF
--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/class.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/class.schema.json
@@ -16,7 +16,7 @@
     },
     "properties": {
       "type": "object",
-      "description": "A dictionary, where each key is a property ID and each value is an object defining the property.",
+      "description": "A dictionary, where each key is a property ID and each value is an object defining the property. Property IDs may contain only alphanumeric and underscore characters.",
       "minProperties": 1,
       "additionalProperties": {
         "$ref": "class.property.schema.json"

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/propertyTable.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/propertyTable.schema.json
@@ -4,6 +4,11 @@
   "type": "object",
   "description": "Features conforming to a class, organized as property values stored in columnar arrays.",
   "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The name of the property, e.g. for display purposes."
+    },
     "class": {
       "type": "string",
       "description": "The class that property values conform to. The value must be a class ID declared in the `classes` dictionary."

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/propertyTexture.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/propertyTexture.schema.json
@@ -7,6 +7,11 @@
   "properties": {
     "index": { },
     "texCoord": { },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The name of the property, e.g. for display purposes."
+    },
     "class": {
       "type": "string",
       "description": "The class this property texture conforms to. The value must be a class ID declared in the `classes` dictionary."

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/schema.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/schema.schema.json
@@ -21,7 +21,7 @@
     },
     "classes": {
       "type": "object",
-      "description": "A dictionary, where each key is a class ID and each value is an object defining the class.",
+      "description": "A dictionary, where each key is a class ID and each value is an object defining the class. Class IDs may contain only alphanumeric and underscore characters.",
       "minProperties": 1,
       "additionalProperties": {
         "$ref": "class.schema.json"
@@ -29,7 +29,7 @@
     },
     "enums": {
       "type": "object",
-      "description": "A dictionary, where each key is an enum ID and each value is an object defining the values for the enum.",
+      "description": "A dictionary, where each key is an enum ID and each value is an object defining the values for the enum. Enum IDs may contain only alphanumeric and underscore characters.",
       "minProperties": 1,
       "additionalProperties": {
         "$ref": "enum.schema.json"


### PR DESCRIPTION
Changes:

- Restrict string IDs for classes, enums, and properties to alphanumeric and underscore characters
- Add "name" to feature tables and textures

Expectation here is that human-readable names may be provided in the "name" property if restrictions don't allow it in the string ID. In languages requiring non-ASCII characters it may be convenient to use IDs like `"property01"` and more meaningful names.