### PR TITLE
EXT_mesh_features: Fixes and tightening of JSON schema.

### DIFF
--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/featureIdAttribute.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/featureIdAttribute.schema.json
@@ -30,9 +30,17 @@
         "attribute"
       ],
       "not": {
-        "required": [
-          "offset",
-          "repeat"
+        "oneOf": [
+          {
+            "required": [
+              "offset"
+            ]
+          },
+          {
+            "required": [
+              "repeat"
+            ]
+          }
         ]
       }
     },

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/featureIdAttribute.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/featureIdAttribute.schema.json
@@ -23,20 +23,26 @@
     "extensions": {},
     "extras": {}
   },
-  "not": {
-    "anyOf": [
-      {
+  "oneOf": [
+    {
+      "description": "Explicit feature ID. 'attribute' is required; 'offset' and 'repeat' are disallowed.",
+      "required": [
+        "attribute"
+      ],
+      "not": {
         "required": [
-          "attribute",
-          "offset"
-        ]
-      },
-      {
-        "required": [
-          "attribute",
+          "offset",
           "repeat"
         ]
       }
-    ]
-  }
+    },
+    {
+      "description": "Implicit feature ID. Both 'offset' and 'repeat' are optional; 'attribute' is disallowed.",
+      "not": {
+        "required": [
+          "attribute"
+        ]
+      }
+    }
+  ]
 }

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/featureIdAttribute.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/featureIdAttribute.schema.json
@@ -30,7 +30,7 @@
         "attribute"
       ],
       "not": {
-        "oneOf": [
+        "anyOf": [
           {
             "required": [
               "offset"

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/featureIdAttribute.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/featureIdAttribute.schema.json
@@ -5,8 +5,8 @@
   "description": "Feature IDs to be used as indices to property arrays in the property table.",
   "properties": {
     "attribute": {
-      "type": "string",
-      "pattern": "^FEATURE_ID_([1-9]\\d*|0)$",
+      "type": "integer",
+      "minimum": 0,
       "description": "The name of the attribute containing feature IDs."
     },
     "offset": {

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/gltf.EXT_mesh_features.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/gltf.EXT_mesh_features.schema.json
@@ -5,7 +5,11 @@
   "description": "glTF extension that assigns metadata to features in a model.",
   "properties": {
     "schema": {
-      "allOf": [ { "$ref": "schema.schema.json" } ],
+      "allOf": [
+        {
+          "$ref": "schema.schema.json"
+        }
+      ],
       "description": "An object defining classes and enums."
     },
     "schemaUri": {
@@ -14,22 +18,40 @@
       "format": "uriref"
     },
     "propertyTables": {
-      "type": "object",
-      "description": "A dictionary, where each key is a property table ID and each value is an object defining the property table.",
-      "minProperties": 1,
-      "additionalProperties": {
+      "type": "array",
+      "description": "An array of property table definitions, which may be referenced by index.",
+      "minItems": 1,
+      "items": {
         "$ref": "propertyTable.schema.json"
       }
     },
     "propertyTextures": {
-      "type": "object",
-      "description": "A dictionary, where each key is a property texture ID and each value is an object defining the property texture.",
-      "minProperties": 1,
-      "additionalProperties": {
+      "type": "array",
+      "description": "An array of property texture definitions, which may be referenced by index.",
+      "minItems": 1,
+      "items": {
         "$ref": "propertyTexture.schema.json"
       }
     },
     "extensions": {},
     "extras": {}
-  }
+  },
+  "oneOf": [
+    {
+      "description": "External schema, if any.",
+      "not": {
+        "required": [
+          "schema"
+        ]
+      }
+    },
+    {
+      "description": "Internal schema, if any.",
+      "not": {
+        "required": [
+          "schemaUri"
+        ]
+      }
+    }
+  ]
 }

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/primitive.EXT_mesh_features.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/primitive.EXT_mesh_features.schema.json
@@ -37,8 +37,7 @@
   "anyOf": [
     {
       "required": [
-        "featureIds",
-        "propertyTables"
+        "featureIds"
       ]
     },
     {

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/propertyTable.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/propertyTable.schema.json
@@ -30,6 +30,8 @@
     "extras": {}
   },
   "required": [
-    "count"
+    "class",
+    "count",
+    "properties"
   ]
 }


### PR DESCRIPTION
Changes:

- Fix schema for root `propertyTables` and `propertyTextures` (objects → arrays)
- Tighten schema for mutually exclusive properties, e.g. `offset` vs. `attribute`
- Update certain required properties