### PR TITLE
Update EXT_feature_metadata to JSON schema 2020-12

### DIFF
--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/EXT_mesh_gpu_instancing/EXT_feature_metadata.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/EXT_mesh_gpu_instancing/EXT_feature_metadata.schema.json
@@ -1,19 +1,24 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "EXT_feature_metadata extension for EXT_mesh_gpu_instancing",
-    "type": "object",
-    "description": "An object describing per-instance feature IDs to be used as indices to property arrays in the feature table.",
-    "properties": {
-      "featureIdAttributes": {
-        "type": "array",
-        "description": "An array of objects mapping per-instance feature IDs to property arrays in a feature table.",
-        "items": {
-          "$ref": "../featureIdAttribute.schema.json"
-        },
-        "minItems": 1
-      },
-      "extensions": {},
-      "extras": {}
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "EXT_feature_metadata.schema.json",
+  "title": "EXT_feature_metadata extension for EXT_mesh_gpu_instancing",
+  "type": "object",
+  "description": "An object describing per-instance feature IDs to be used as indices to property arrays in the feature table.",
+  "allOf": [
+    {
+      "$ref": "glTFProperty.schema.json"
     }
+  ],
+  "properties": {
+    "featureIdAttributes": {
+      "type": "array",
+      "description": "An array of objects mapping per-instance feature IDs to property arrays in a feature table.",
+      "items": {
+        "$ref": "../featureIdAttribute.schema.json"
+      },
+      "minItems": 1
+    },
+    "extensions": {},
+    "extras": {}
   }
- 
+}

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
@@ -1,8 +1,14 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "class.property.schema.json",
   "title": "Class property",
   "type": "object",
   "description": "A class property.",
+  "allOf": [
+    {
+      "$ref": "glTFProperty.schema.json"
+    }
+  ],
   "properties": {
     "name": {
       "type": "string",
@@ -15,46 +21,105 @@
       "description": "The description of the property."
     },
     "type": {
-      "type": "string",
-      "enum": [
-        "INT8",
-        "UINT8",
-        "INT16",
-        "UINT16",
-        "INT32",
-        "UINT32",
-        "INT64",
-        "UINT64",
-        "FLOAT32",
-        "FLOAT64",
-        "BOOLEAN",
-        "STRING",
-        "ENUM",
-        "ARRAY"
-      ],
-      "description": "The property type. If `ENUM` is used, then `enumType` must also be specified. If `ARRAY` is used, then `componentType` must also be specified. `ARRAY` is a fixed-length array when `componentCount` is defined, and variable-length otherwise."
+      "description": "The property type. If `ENUM` is used, then `enumType` must also be specified. If `ARRAY` is used, then `componentType` must also be specified. `ARRAY` is a fixed-length array when `componentCount` is defined, and variable-length otherwise.",
+      "anyOf": [
+        {
+          "const": "INT8"
+        },
+        {
+          "const": "UINT8"
+        },
+        {
+          "const": "INT16"
+        },
+        {
+          "const": "UINT16"
+        },
+        {
+          "const": "INT32"
+        },
+        {
+          "const": "UINT32"
+        },
+        {
+          "const": "INT64"
+        },
+        {
+          "const": "UINT64"
+        },
+        {
+          "const": "FLOAT32"
+        },
+        {
+          "const": "FLOAT64"
+        },
+        {
+          "const": "BOOLEAN"
+        },
+        {
+          "const": "STRING"
+        },
+        {
+          "const": "ENUM"
+        },
+        {
+          "const": "ARRAY"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "enumType": {
       "type": "string",
       "description": "An enum ID as declared in the `enums` dictionary. This value must be specified when `type` or `componentType` is `ENUM`."
     },
     "componentType": {
-      "enum": [
-        "INT8",
-        "UINT8",
-        "INT16",
-        "UINT16",
-        "INT32",
-        "UINT32",
-        "INT64",
-        "UINT64",
-        "FLOAT32",
-        "FLOAT64",
-        "BOOLEAN",
-        "STRING",
-        "ENUM"
-      ],
-      "description": "When `type` is `ARRAY` this indicates the type of each component of the array. If `ENUM` is used, then `enumType` must also be specified."
+      "description": "When `type` is `ARRAY` this indicates the type of each component of the array. If `ENUM` is used, then `enumType` must also be specified.",
+      "anyOf": [
+        {
+          "const": "INT8"
+        },
+        {
+          "const": "UINT8"
+        },
+        {
+          "const": "INT16"
+        },
+        {
+          "const": "UINT16"
+        },
+        {
+          "const": "INT32"
+        },
+        {
+          "const": "UINT32"
+        },
+        {
+          "const": "INT64"
+        },
+        {
+          "const": "UINT64"
+        },
+        {
+          "const": "FLOAT32"
+        },
+        {
+          "const": "FLOAT64"
+        },
+        {
+          "const": "BOOLEAN"
+        },
+        {
+          "const": "STRING"
+        },
+        {
+          "const": "ENUM"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "componentCount": {
       "type": "integer",

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.schema.json
@@ -1,8 +1,14 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "class.schema.json",
   "title": "Class",
   "type": "object",
   "description": "A class containing a set of properties.",
+  "allOf": [
+    {
+      "$ref": "glTFProperty.schema.json"
+    }
+  ],
   "properties": {
     "name": {
       "type": "string",

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/enum.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/enum.schema.json
@@ -1,8 +1,14 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "enum.schema.json",
   "title": "Enum",
   "type": "object",
   "description": "An object defining the values of an enum.",
+  "allOf": [
+    {
+      "$ref": "glTFProperty.schema.json"
+    }
+  ],
   "properties": {
     "name": {
       "type": "string",
@@ -15,19 +21,37 @@
       "description": "The description of the enum."
     },
     "valueType": {
-      "type": "string",
+      "description": "The type of the integer enum value.",
       "default": "UINT16",
-      "enum": [
-        "INT8",
-        "UINT8",
-        "INT16",
-        "UINT16",
-        "INT32",
-        "UINT32",
-        "INT64",
-        "UINT64"
-      ],
-      "description": "The type of the integer enum value."
+      "anyOf": [
+        {
+          "const": "INT8"
+        },
+        {
+          "const": "UINT8"
+        },
+        {
+          "const": "INT16"
+        },
+        {
+          "const": "UINT16"
+        },
+        {
+          "const": "INT32"
+        },
+        {
+          "const": "UINT32"
+        },
+        {
+          "const": "INT64"
+        },
+        {
+          "const": "UINT64"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "values": {
       "type": "array",

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/enum.value.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/enum.value.schema.json
@@ -1,8 +1,14 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "enum.value.schema.json",
   "title": "Enum value",
   "type": "object",
   "description": "An enum value.",
+  "allOf": [
+    {
+      "$ref": "glTFProperty.schema.json"
+    }
+  ],
   "properties": {
     "name": {
       "type": "string",

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdAttribute.featureIds.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdAttribute.featureIds.schema.json
@@ -1,8 +1,14 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "featureIdAttribute.featureIds.schema.json",
   "title": "Feature IDs",
   "type": "object",
   "description": "Feature IDs to be used as indices to property arrays in the feature table.",
+  "allOf": [
+    {
+      "$ref": "glTFProperty.schema.json"
+    }
+  ],
   "properties": {
     "attribute": {
       "type": "string",

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdAttribute.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdAttribute.schema.json
@@ -1,15 +1,25 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "featureIdAttribute.schema.json",
   "title": "Feature ID Attribute",
   "type": "object",
   "description": "An object mapping feature IDs to a feature table.",
+  "allOf": [
+    {
+      "$ref": "glTFProperty.schema.json"
+    }
+  ],
   "properties": {
     "featureTable": {
       "type": "string",
       "description": "The ID of the feature table in the model's root `EXT_feature_metadata.featureTables` dictionary."
     },
     "featureIds": {
-      "allOf": [ { "$ref": "featureIdAttribute.featureIds.schema.json" } ],
+      "allOf": [
+        {
+          "$ref": "featureIdAttribute.featureIds.schema.json"
+        }
+      ],
       "description": "An object describing feature IDs to be used as indices to property arrays in the feature table. Feature IDs must be whole numbers in the range `[0, count - 1]` (inclusive), where `count` is the total number of features in the feature table."
     },
     "extensions": {},

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdTexture.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdTexture.schema.json
@@ -1,15 +1,25 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "featureIdTexture.schema.json",
   "title": "Feature ID Texture",
   "type": "object",
   "description": "An object describing a texture used for storing per-texel feature IDs.",
+  "allOf": [
+    {
+      "$ref": "glTFProperty.schema.json"
+    }
+  ],
   "properties": {
     "featureTable": {
       "type": "string",
       "description": "The ID of the feature table in the model's root `EXT_feature_metadata.featureTables` dictionary."
     },
     "featureIds": {
-      "allOf": [ { "$ref": "textureAccessor.schema.json" } ],
+      "allOf": [
+        {
+          "$ref": "textureAccessor.schema.json"
+        }
+      ],
       "description": "A description of the texture and channel to use for feature IDs. The `channels` property must have a single channel. Furthermore, feature IDs must be whole numbers in the range `[0, count - 1]` (inclusive), where `count` is the total number of features in the feature table. Texel values must be read as integers. Texture filtering should be disabled when fetching feature IDs."
     },
     "extensions": {},

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureTable.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureTable.property.schema.json
@@ -1,30 +1,58 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "featureTable.property.schema.json",
   "title": "Feature Table Property",
   "type": "object",
   "description": "An array of binary property values.",
+  "allOf": [
+    {
+      "$ref": "glTFProperty.schema.json"
+    }
+  ],
   "properties": {
     "bufferView": {
-      "allOf": [ { "$ref": "glTFid.schema.json" } ],
+      "allOf": [
+        {
+          "$ref": "glTFid.schema.json"
+        }
+      ],
       "description": "The index of the buffer view containing property values. The data type of property values is determined by the property definition: When `type` is `BOOLEAN` values are packed into a bitfield. When `type` is `STRING` values are stored as byte sequences and decoded as UTF-8 strings. When `type` is a numeric type values are stored as the provided `type`. When `type` is `ENUM` values are stored as the enum's `valueType`. Each enum value in the buffer must match one of the allowed values in the enum definition. When `type` is `ARRAY` elements are packed tightly together and the data type is based on the `componentType` following the same rules as above. `arrayOffsetBufferView` is required for variable-size arrays and `stringOffsetBufferView` is required for strings (for variable-length arrays of strings, both are required). The buffer view `byteOffset` must be aligned to a multiple of 8 bytes. If the buffer view's `buffer` is the GLB-stored `BIN` chunk, the byte offset is measured relative to the beginning of the GLB. Otherwise, it is measured relative to the beginning of the buffer."
     },
     "offsetType": {
-      "type": "string",
+      "description": "The type of values in `arrayOffsetBufferView` and `stringOffsetBufferView`.",
       "default": "UINT32",
-      "enum": [
-        "UINT8",
-        "UINT16",
-        "UINT32",
-        "UINT64"
-      ],
-      "description": "The type of values in `arrayOffsetBufferView` and `stringOffsetBufferView`."
+      "anyOf": [
+        {
+          "const": "UINT8"
+        },
+        {
+          "const": "UINT16"
+        },
+        {
+          "const": "UINT32"
+        },
+        {
+          "const": "UINT64"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "arrayOffsetBufferView": {
-      "allOf": [ { "$ref": "glTFid.schema.json" } ],
+      "allOf": [
+        {
+          "$ref": "glTFid.schema.json"
+        }
+      ],
       "description": "The index of the buffer view containing offsets for variable-length arrays. The number of offsets is equal to the feature table `count` plus one. The offsets represent the start positions of each array, with the last offset representing the position after the last array. The array length is computed using the difference between the current offset and the subsequent offset. If `componentType` is `STRING` the offsets index into the string offsets array (stored in `stringOffsetBufferView`), otherwise they index into the property array (stored in `bufferView`). The data type of these offsets is determined by `offsetType`. The buffer view `byteOffset` must be aligned to a multiple of 8 bytes in the same manner as the main `bufferView`"
     },
     "stringOffsetBufferView": {
-      "allOf": [ { "$ref": "glTFid.schema.json" } ],
+      "allOf": [
+        {
+          "$ref": "glTFid.schema.json"
+        }
+      ],
       "description": "The index of the buffer view containing offsets for strings. The number of offsets is equal to the number of string components plus one. The offsets represent the byte offsets of each string in the main `bufferView`, with the last offset representing the byte offset after the last string. The string byte length is computed using the difference between the current offset and the subsequent offset. The data type of these offsets is determined by `offsetType`. The buffer view `byteOffset` must be aligned to a multiple of 8 bytes in the same manner as the main `bufferView`."
     },
     "extensions": {},

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureTable.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureTable.schema.json
@@ -1,8 +1,14 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "featureTable.schema.json",
   "title": "Feature Table",
   "type": "object",
   "description": "A feature table defined by a class and property values stored in arrays.",
+  "allOf": [
+    {
+      "$ref": "glTFProperty.schema.json"
+    }
+  ],
   "properties": {
     "class": {
       "type": "string",

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureTexture.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureTexture.schema.json
@@ -1,8 +1,14 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "featureTexture.schema.json",
   "title": "Feature Texture",
   "type": "object",
   "description": "Features whose property values are stored directly in texture channels. This is not to be confused with feature ID textures which store feature IDs for use with a feature table.",
+  "allOf": [
+    {
+      "$ref": "glTFProperty.schema.json"
+    }
+  ],
   "properties": {
     "class": {
       "type": "string",

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/glTF.EXT_feature_metadata.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/glTF.EXT_feature_metadata.schema.json
@@ -1,20 +1,34 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "glTF.EXT_feature_metadata.schema.json",
   "title": "EXT_feature_metadata glTF extension",
   "type": "object",
   "description": "glTF extension that assigns metadata to features in a model.",
+  "allOf": [
+    {
+      "$ref": "glTFProperty.schema.json"
+    }
+  ],
   "properties": {
     "schema": {
-      "allOf": [ { "$ref": "schema.schema.json" } ],
+      "allOf": [
+        {
+          "$ref": "schema.schema.json"
+        }
+      ],
       "description": "An object defining classes and enums."
     },
     "schemaUri": {
       "type": "string",
-      "description": "A uri to an external schema file.",
-      "format": "uriref"
+      "description": "The URI (or IRI) of the external schema file.",
+      "format": "iri-reference"
     },
     "statistics": {
-      "allOf": [ { "$ref": "statistics.schema.json" } ],
+      "allOf": [
+        {
+          "$ref": "statistics.schema.json"
+        }
+      ],
       "description": "An object containing statistics about features."
     },
     "featureTables": {

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/primitive.EXT_feature_metadata.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/primitive.EXT_feature_metadata.schema.json
@@ -1,8 +1,14 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "primitive.EXT_feature_metadata.schema.json",
   "title": "EXT_feature_metadata glTF Primitive extension",
   "type": "object",
   "description": "`EXT_feature_metadata extension` for a primitive in a glTF model, to associate it with the root `EXT_feature_metadata` object.",
+  "allOf": [
+    {
+      "$ref": "glTFProperty.schema.json"
+    }
+  ],
   "properties": {
     "featureIdAttributes": {
       "type": "array",

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/schema.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/schema.schema.json
@@ -1,8 +1,14 @@
 {
-  "$schema": "https://json-schema.org/draft-04/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schema.schema.json",
   "title": "Schema",
   "type": "object",
   "description": "An object defining classes and enums.",
+  "allOf": [
+    {
+      "$ref": "glTFProperty.schema.json"
+    }
+  ],
   "properties": {
     "name": {
       "type": "string",

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/statistics.class.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/statistics.class.property.schema.json
@@ -1,8 +1,14 @@
 {
-  "$schema": "https://json-schema.org/draft-04/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "statistics.class.property.schema.json",
   "title": "Property Statistics",
   "type": "object",
   "description": "Statistics about property values.",
+  "allOf": [
+    {
+      "$ref": "glTFProperty.schema.json"
+    }
+  ],
   "properties": {
     "min": {
       "type": [

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/statistics.class.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/statistics.class.schema.json
@@ -1,8 +1,14 @@
 {
-  "$schema": "https://json-schema.org/draft-04/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "statistics.class.schema.json",
   "title": "Class Statistics",
   "type": "object",
   "description": "Statistics about features that conform to the class.",
+  "allOf": [
+    {
+      "$ref": "glTFProperty.schema.json"
+    }
+  ],
   "properties": {
     "count": {
       "type": "integer",

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/statistics.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/statistics.schema.json
@@ -1,8 +1,14 @@
 {
-  "$schema": "https://json-schema.org/draft-04/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "statistics.schema.json",
   "title": "Statistics",
   "type": "object",
   "description": "Statistics about features.",
+  "allOf": [
+    {
+      "$ref": "glTFProperty.schema.json"
+    }
+  ],
   "properties": {
     "classes": {
       "type": "object",

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/textureAccessor.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/textureAccessor.schema.json
@@ -1,8 +1,14 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "textureAccessor.schema.json",
   "title": "Texture Accessor",
-  "description": "A description of how to access property values from the color channels of a texture.",
   "type": "object",
+  "description": "A description of how to access property values from the color channels of a texture.",
+  "allOf": [
+    {
+      "$ref": "glTFProperty.schema.json"
+    }
+  ],
   "properties": {
     "channels": {
       "type": "string",
@@ -10,7 +16,11 @@
       "description": "Texture channels containing property values. Channels are labeled by `rgba` and are swizzled with a string of 1-4 characters."
     },
     "texture": {
-      "allOf": [ { "$ref": "textureInfo.schema.json" } ],
+      "allOf": [
+        {
+          "$ref": "textureInfo.schema.json"
+        }
+      ],
       "description": "The glTF texture and texture coordinates to use."
     },
     "extensions": {},


### PR DESCRIPTION
Similar to https://github.com/CesiumGS/glTF/pull/28 but for `EXT_feature_metadata`.

* Switched from JSON schema draft-4 to JSON schema 2020-12
* Formatted the schema files with the built-in VSCode JSON formatter
* Removed enum arrays in favor of glTF-style enums ([example](https://github.com/KhronosGroup/glTF/blob/f8c5f84c974508bcf4eadbc4943f4f7dcb1c3d89/specification/2.0/schema/accessor.schema.json#L26-L60))
* Every object now extends [`glTFProperty.schema.json`](https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/glTFProperty.schema.json)
* Renamed `gltf.EXT_feature_metadata.schema.json` to `glTF.EXT_feature_metadata.schema.json`
