### PR TITLE
Update broken links

### DIFF
--- a/extensions/2.0/Vendor/EXT_mesh_features/README.md
+++ b/extensions/2.0/Vendor/EXT_mesh_features/README.md
@@ -206,7 +206,7 @@ Texture filtering must be `9728` (NEAREST), or undefined, for any texture object
 
 ### Feature ID by GPU Instance
 
-*Defined in [featureIdAttribute.schema.json](./schema/featureIdAttribute.schema.json).*
+*Defined in [node.EXT_mesh_features.schema.json](./schema/node.EXT_mesh_features.schema.json).*
 
 Feature IDs may also be assigned to individual GPU instances when using the [`EXT_mesh_gpu_instancing` extension](../EXT_mesh_gpu_instancing). Similar to per-vertex IDs, per-instance IDs are stored in instance attributes or generated implicitly by instance index. Nodes with `EXT_mesh_features` must also define an `EXT_mesh_gpu_instancing` extension, and are invalid without this dependency.
 
@@ -492,7 +492,7 @@ The property table may provide value arrays for only a subset of the properties 
 > }
 > ```
 
-Property arrays are stored in glTF buffer views and use the binary encoding defined in the [Table Format](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/specification/Metadata#table-format) section of the [Cesium 3D Metadata Specification](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/specification/Metadata).
+Property arrays are stored in glTF buffer views and use the binary encoding defined in the [Binary Table Format](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/specification/Metadata#binary-table-format) section of the [Cesium 3D Metadata Specification](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/specification/Metadata).
 
 As in the core glTF specification, values of NaN, +Infinity, and -Infinity are never allowed.
 
@@ -699,3 +699,4 @@ Composite|A glTF containing a 3D mesh (house), a point cloud (tree), and instanc
   * Refactored `type` and `componentType` to avoid overlap. Properties that store a single value now have a `type` of `SINGLE` and a `componentType` of the desired type (e.g. `type: "SINGLE", componentType: "UINT8"`)
   * Class IDs, enum IDs, and property IDs must now contain only alphanumeric and underscore characters
   * Clarified that nodes with GPU instancing cannot reference property textures
+  * For GPU instance metadata, the `EXT_mesh_features` extension is now scoped to the `node` extensions instead of nesting inside the `EXT_mesh_gpu_instancing` extension.

--- a/extensions/2.0/Vendor/EXT_mesh_features/README.md
+++ b/extensions/2.0/Vendor/EXT_mesh_features/README.md
@@ -84,7 +84,7 @@ Features are identified within a 3D asset by **Feature IDs** (unique identifiers
 
 #### Vertex Attribute
 
-*Defined in [featureIdAttribute.schema.json](./schema/featureIdAttribute.schema.json).*
+*Defined in [primitive.EXT_mesh_features.schema.json](./schema/primitive.EXT_mesh_features.schema.json) and [featureIdAttribute.schema.json](./schema/featureIdAttribute.schema.json).*
 
 Per-vertex feature IDs may be defined explicitly in a vertex attribute accessor.
 
@@ -125,7 +125,7 @@ The attribute's accessor `type` must be `"SCALAR"` and `normalized` must be fals
 
 #### Implicit Vertex Attribute
 
-*Defined in [featureIdAttribute.schema.json](./schema/featureIdAttribute.schema.json).*
+*Defined in [primitive.EXT_mesh_features.schema.json](./schema/primitive.EXT_mesh_features.schema.json) and [featureIdAttribute.schema.json](./schema/featureIdAttribute.schema.json).*
 
 Per-vertex feature IDs may also be defined implicitly, as a function of vertex index within the primitive. Implicit feature IDs reduce storage costs in several common cases, such as when all vertices in a primitive share the same feature ID, or each sequential group of `N` vertices (e.g. each triangle face) share the same feature ID.
 
@@ -167,7 +167,7 @@ For example
 
 ### Feature ID by Texture Coordinates
 
-*Defined in [featureIdTexture.schema.json](./schema/featureIdTexture.schema.json).*
+*Defined in [primitive.EXT_mesh_features.schema.json](./schema/primitive.EXT_mesh_features.schema.json) and [featureIdTexture.schema.json](./schema/featureIdTexture.schema.json).*
 
 Feature ID textures classify the pixels of an image into different features. Some use cases include image segmentation or marking regions on a map. Often per-texel feature IDs provide finer granularity than per-vertex feature IDs, as in the example below.
 
@@ -206,7 +206,7 @@ Texture filtering must be `9728` (NEAREST), or undefined, for any texture object
 
 ### Feature ID by GPU Instance
 
-*Defined in [node.EXT_mesh_features.schema.json](./schema/node.EXT_mesh_features.schema.json).*
+*Defined in [node.EXT_mesh_features.schema.json](./schema/node.EXT_mesh_features.schema.json) and [featureIdAttribute.schema.json](./schema/featureIdAttribute.schema.json).*
 
 Feature IDs may also be assigned to individual GPU instances when using the [`EXT_mesh_gpu_instancing` extension](../EXT_mesh_gpu_instancing). Similar to per-vertex IDs, per-instance IDs are stored in instance attributes or generated implicitly by instance index. Nodes with `EXT_mesh_features` must also define an `EXT_mesh_gpu_instancing` extension, and are invalid without this dependency.
 


### PR DESCRIPTION
[Direct link to extension](https://github.com/CesiumGS/glTF/tree/mesh-features-fix-links/extensions/2.0/Vendor/EXT_mesh_features)

* I noticed a couple broken links and fixed them
* Also noticed a missing changelog entry about the fact that the instancing metadata extension now lives in the node instead of the `EXT_mesh_gpu_instancing` extension

@donmccurdy could you review?