### PR TITLE
EXT_mesh_features: Additional clarification that VECN and MATN are numeric

### DIFF
--- a/extensions/2.0/Vendor/EXT_mesh_features/README.md
+++ b/extensions/2.0/Vendor/EXT_mesh_features/README.md
@@ -366,6 +366,8 @@ Allowed values for `type`:
 - `"VEC2"`, `"VEC3"`, `"VEC4"`
 - `"MAT2"`, `"MAT3"`, `"MAT4"`
 
+`"SINGLE"` and `"ARRAY"` types may contain any component type; `"VECN"` and `"MATN"` must contain only numeric component types.
+
 Class properties are defined as entries in the `class.properties` dictionary, indexed by an alphanumeric property ID.
 
 > **Example:** A "Tree" class, which might describe a table of tree measurements taken in a park. Properties include species, height, and diameter of each tree, as well as the number of birds observed in its branches.


### PR DESCRIPTION
Continued from https://github.com/CesiumGS/glTF/pull/33.