### PR TITLE
Use 4 spaces for indentation

### DIFF
--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/EXT_mesh_gpu_instancing/EXT_feature_metadata.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/EXT_mesh_gpu_instancing/EXT_feature_metadata.schema.json
@@ -1,24 +1,24 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "EXT_feature_metadata.schema.json",
-  "title": "EXT_feature_metadata extension for EXT_mesh_gpu_instancing",
-  "type": "object",
-  "description": "An object describing per-instance feature IDs to be used as indices to property arrays in the feature table.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "EXT_feature_metadata.schema.json",
+    "title": "EXT_feature_metadata extension for EXT_mesh_gpu_instancing",
+    "type": "object",
+    "description": "An object describing per-instance feature IDs to be used as indices to property arrays in the feature table.",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "featureIdAttributes": {
+            "type": "array",
+            "description": "An array of objects mapping per-instance feature IDs to property arrays in a feature table.",
+            "items": {
+                "$ref": "../featureIdAttribute.schema.json"
+            },
+            "minItems": 1
+        },
+        "extensions": {},
+        "extras": {}
     }
-  ],
-  "properties": {
-    "featureIdAttributes": {
-      "type": "array",
-      "description": "An array of objects mapping per-instance feature IDs to property arrays in a feature table.",
-      "items": {
-        "$ref": "../featureIdAttribute.schema.json"
-      },
-      "minItems": 1
-    },
-    "extensions": {},
-    "extras": {}
-  }
 }

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.property.schema.json
@@ -1,187 +1,187 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "class.property.schema.json",
-  "title": "Class property",
-  "type": "object",
-  "description": "A class property.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "name": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The name of the property, e.g. for display purposes."
-    },
-    "description": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The description of the property."
-    },
-    "type": {
-      "description": "The property type. If `ENUM` is used, then `enumType` must also be specified. If `ARRAY` is used, then `componentType` must also be specified. `ARRAY` is a fixed-length array when `componentCount` is defined, and variable-length otherwise.",
-      "anyOf": [
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "class.property.schema.json",
+    "title": "Class property",
+    "type": "object",
+    "description": "A class property.",
+    "allOf": [
         {
-          "const": "INT8"
-        },
-        {
-          "const": "UINT8"
-        },
-        {
-          "const": "INT16"
-        },
-        {
-          "const": "UINT16"
-        },
-        {
-          "const": "INT32"
-        },
-        {
-          "const": "UINT32"
-        },
-        {
-          "const": "INT64"
-        },
-        {
-          "const": "UINT64"
-        },
-        {
-          "const": "FLOAT32"
-        },
-        {
-          "const": "FLOAT64"
-        },
-        {
-          "const": "BOOLEAN"
-        },
-        {
-          "const": "STRING"
-        },
-        {
-          "const": "ENUM"
-        },
-        {
-          "const": "ARRAY"
-        },
-        {
-          "type": "string"
+            "$ref": "glTFProperty.schema.json"
         }
-      ]
-    },
-    "enumType": {
-      "type": "string",
-      "description": "An enum ID as declared in the `enums` dictionary. This value must be specified when `type` or `componentType` is `ENUM`."
-    },
-    "componentType": {
-      "description": "When `type` is `ARRAY` this indicates the type of each component of the array. If `ENUM` is used, then `enumType` must also be specified.",
-      "anyOf": [
-        {
-          "const": "INT8"
-        },
-        {
-          "const": "UINT8"
-        },
-        {
-          "const": "INT16"
-        },
-        {
-          "const": "UINT16"
-        },
-        {
-          "const": "INT32"
-        },
-        {
-          "const": "UINT32"
-        },
-        {
-          "const": "INT64"
-        },
-        {
-          "const": "UINT64"
-        },
-        {
-          "const": "FLOAT32"
-        },
-        {
-          "const": "FLOAT64"
-        },
-        {
-          "const": "BOOLEAN"
-        },
-        {
-          "const": "STRING"
-        },
-        {
-          "const": "ENUM"
-        },
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "componentCount": {
-      "type": "integer",
-      "minimum": 2,
-      "description": "The number of components per element for `ARRAY` elements."
-    },
-    "normalized": {
-      "type": "boolean",
-      "description": "Specifies whether integer values are normalized. This applies both when `type` is an integer type, or when `type` is `ARRAY` with a `componentType` that is an integer type. For unsigned integer types, values are normalized between `[0.0, 1.0]`. For signed integer types, values are normalized between `[-1.0, 1.0]`. For all other types, this property is ignored.",
-      "default": false
-    },
-    "max": {
-      "type": [
-        "number",
-        "array"
-      ],
-      "items": {
-        "type": "number"
-      },
-      "description": "Maximum allowed values for property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values: they always correspond to the integer values."
-    },
-    "min": {
-      "type": [
-        "number",
-        "array"
-      ],
-      "items": {
-        "type": "number"
-      },
-      "description": "Minimum allowed values for property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values: they always correspond to the integer values."
-    },
-    "default": {
-      "type": [
-        "boolean",
-        "number",
-        "string",
-        "array"
-      ],
-      "description": "A default value to use when the property value is not defined. If used, `optional` must be set to true. The type of the default value must match the property definition: For `BOOLEAN` use `true` or `false`. For `STRING` use a JSON string. For a numeric type use a JSON number. For `ENUM` use the enum `name`, not the integer value. For `ARRAY` use a JSON array containing values matching the `componentType`."
-    },
-    "optional": {
-      "type": "boolean",
-      "description": "If true, this property is optional.",
-      "default": false
-    },
-    "semantic": {
-      "type": "string",
-      "minLength": 1,
-      "description": "An identifier that describes how this property should be interpreted. The semantic cannot be used by other properties in the class."
-    },
-    "extensions": {},
-    "extras": {}
-  },
-  "dependencies": {
-    "componentCount": [
-      "componentType"
     ],
-    "default": [
-      "optional"
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the property, e.g. for display purposes."
+        },
+        "description": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The description of the property."
+        },
+        "type": {
+            "description": "The property type. If `ENUM` is used, then `enumType` must also be specified. If `ARRAY` is used, then `componentType` must also be specified. `ARRAY` is a fixed-length array when `componentCount` is defined, and variable-length otherwise.",
+            "anyOf": [
+                {
+                    "const": "INT8"
+                },
+                {
+                    "const": "UINT8"
+                },
+                {
+                    "const": "INT16"
+                },
+                {
+                    "const": "UINT16"
+                },
+                {
+                    "const": "INT32"
+                },
+                {
+                    "const": "UINT32"
+                },
+                {
+                    "const": "INT64"
+                },
+                {
+                    "const": "UINT64"
+                },
+                {
+                    "const": "FLOAT32"
+                },
+                {
+                    "const": "FLOAT64"
+                },
+                {
+                    "const": "BOOLEAN"
+                },
+                {
+                    "const": "STRING"
+                },
+                {
+                    "const": "ENUM"
+                },
+                {
+                    "const": "ARRAY"
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        },
+        "enumType": {
+            "type": "string",
+            "description": "An enum ID as declared in the `enums` dictionary. This value must be specified when `type` or `componentType` is `ENUM`."
+        },
+        "componentType": {
+            "description": "When `type` is `ARRAY` this indicates the type of each component of the array. If `ENUM` is used, then `enumType` must also be specified.",
+            "anyOf": [
+                {
+                    "const": "INT8"
+                },
+                {
+                    "const": "UINT8"
+                },
+                {
+                    "const": "INT16"
+                },
+                {
+                    "const": "UINT16"
+                },
+                {
+                    "const": "INT32"
+                },
+                {
+                    "const": "UINT32"
+                },
+                {
+                    "const": "INT64"
+                },
+                {
+                    "const": "UINT64"
+                },
+                {
+                    "const": "FLOAT32"
+                },
+                {
+                    "const": "FLOAT64"
+                },
+                {
+                    "const": "BOOLEAN"
+                },
+                {
+                    "const": "STRING"
+                },
+                {
+                    "const": "ENUM"
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        },
+        "componentCount": {
+            "type": "integer",
+            "minimum": 2,
+            "description": "The number of components per element for `ARRAY` elements."
+        },
+        "normalized": {
+            "type": "boolean",
+            "description": "Specifies whether integer values are normalized. This applies both when `type` is an integer type, or when `type` is `ARRAY` with a `componentType` that is an integer type. For unsigned integer types, values are normalized between `[0.0, 1.0]`. For signed integer types, values are normalized between `[-1.0, 1.0]`. For all other types, this property is ignored.",
+            "default": false
+        },
+        "max": {
+            "type": [
+                "number",
+                "array"
+            ],
+            "items": {
+                "type": "number"
+            },
+            "description": "Maximum allowed values for property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values: they always correspond to the integer values."
+        },
+        "min": {
+            "type": [
+                "number",
+                "array"
+            ],
+            "items": {
+                "type": "number"
+            },
+            "description": "Minimum allowed values for property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values: they always correspond to the integer values."
+        },
+        "default": {
+            "type": [
+                "boolean",
+                "number",
+                "string",
+                "array"
+            ],
+            "description": "A default value to use when the property value is not defined. If used, `optional` must be set to true. The type of the default value must match the property definition: For `BOOLEAN` use `true` or `false`. For `STRING` use a JSON string. For a numeric type use a JSON number. For `ENUM` use the enum `name`, not the integer value. For `ARRAY` use a JSON array containing values matching the `componentType`."
+        },
+        "optional": {
+            "type": "boolean",
+            "description": "If true, this property is optional.",
+            "default": false
+        },
+        "semantic": {
+            "type": "string",
+            "minLength": 1,
+            "description": "An identifier that describes how this property should be interpreted. The semantic cannot be used by other properties in the class."
+        },
+        "extensions": {},
+        "extras": {}
+    },
+    "dependencies": {
+        "componentCount": [
+            "componentType"
+        ],
+        "default": [
+            "optional"
+        ]
+    },
+    "required": [
+        "type"
     ]
-  },
-  "required": [
-    "type"
-  ]
 }

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/class.schema.json
@@ -1,34 +1,34 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "class.schema.json",
-  "title": "Class",
-  "type": "object",
-  "description": "A class containing a set of properties.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "name": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The name of the class, e.g. for display purposes."
-    },
-    "description": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The description of the class."
-    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "class.schema.json",
+    "title": "Class",
+    "type": "object",
+    "description": "A class containing a set of properties.",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
     "properties": {
-      "type": "object",
-      "description": "A dictionary, where each key is a property ID and each value is an object defining the property.",
-      "minProperties": 1,
-      "additionalProperties": {
-        "$ref": "class.property.schema.json"
-      }
-    },
-    "extensions": {},
-    "extras": {}
-  }
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the class, e.g. for display purposes."
+        },
+        "description": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The description of the class."
+        },
+        "properties": {
+            "type": "object",
+            "description": "A dictionary, where each key is a property ID and each value is an object defining the property.",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "class.property.schema.json"
+            }
+        },
+        "extensions": {},
+        "extras": {}
+    }
 }

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/enum.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/enum.schema.json
@@ -1,70 +1,70 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "enum.schema.json",
-  "title": "Enum",
-  "type": "object",
-  "description": "An object defining the values of an enum.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "name": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The name of the enum, e.g. for display purposes."
-    },
-    "description": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The description of the enum."
-    },
-    "valueType": {
-      "description": "The type of the integer enum value.",
-      "default": "UINT16",
-      "anyOf": [
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "enum.schema.json",
+    "title": "Enum",
+    "type": "object",
+    "description": "An object defining the values of an enum.",
+    "allOf": [
         {
-          "const": "INT8"
-        },
-        {
-          "const": "UINT8"
-        },
-        {
-          "const": "INT16"
-        },
-        {
-          "const": "UINT16"
-        },
-        {
-          "const": "INT32"
-        },
-        {
-          "const": "UINT32"
-        },
-        {
-          "const": "INT64"
-        },
-        {
-          "const": "UINT64"
-        },
-        {
-          "type": "string"
+            "$ref": "glTFProperty.schema.json"
         }
-      ]
+    ],
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the enum, e.g. for display purposes."
+        },
+        "description": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The description of the enum."
+        },
+        "valueType": {
+            "description": "The type of the integer enum value.",
+            "default": "UINT16",
+            "anyOf": [
+                {
+                    "const": "INT8"
+                },
+                {
+                    "const": "UINT8"
+                },
+                {
+                    "const": "INT16"
+                },
+                {
+                    "const": "UINT16"
+                },
+                {
+                    "const": "INT32"
+                },
+                {
+                    "const": "UINT32"
+                },
+                {
+                    "const": "INT64"
+                },
+                {
+                    "const": "UINT64"
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        },
+        "values": {
+            "type": "array",
+            "description": "An array of enum values. Duplicate names or duplicate integer values are not allowed.",
+            "items": {
+                "$ref": "enum.value.schema.json"
+            },
+            "minItems": 1
+        },
+        "extensions": {},
+        "extras": {}
     },
-    "values": {
-      "type": "array",
-      "description": "An array of enum values. Duplicate names or duplicate integer values are not allowed.",
-      "items": {
-        "$ref": "enum.value.schema.json"
-      },
-      "minItems": 1
-    },
-    "extensions": {},
-    "extras": {}
-  },
-  "required": [
-    "values"
-  ]
+    "required": [
+        "values"
+    ]
 }

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/enum.value.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/enum.value.schema.json
@@ -1,34 +1,34 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "enum.value.schema.json",
-  "title": "Enum value",
-  "type": "object",
-  "description": "An enum value.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "name": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The name of the enum value."
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "enum.value.schema.json",
+    "title": "Enum value",
+    "type": "object",
+    "description": "An enum value.",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the enum value."
+        },
+        "description": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The description of the enum value."
+        },
+        "value": {
+            "type": "integer",
+            "description": "The integer enum value."
+        },
+        "extensions": {},
+        "extras": {}
     },
-    "description": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The description of the enum value."
-    },
-    "value": {
-      "type": "integer",
-      "description": "The integer enum value."
-    },
-    "extensions": {},
-    "extras": {}
-  },
-  "required": [
-    "name",
-    "value"
-  ]
+    "required": [
+        "name",
+        "value"
+    ]
 }

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdAttribute.featureIds.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdAttribute.featureIds.schema.json
@@ -1,49 +1,49 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "featureIdAttribute.featureIds.schema.json",
-  "title": "Feature IDs",
-  "type": "object",
-  "description": "Feature IDs to be used as indices to property arrays in the feature table.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "attribute": {
-      "type": "string",
-      "pattern": "^_FEATURE_ID_([1-9]\\d*|0)$",
-      "description": "The name of the attribute containing feature IDs."
-    },
-    "constant": {
-      "type": "integer",
-      "minimum": 0,
-      "default": 0,
-      "description": "Sets a constant feature ID when the attribute property is omitted."
-    },
-    "divisor": {
-      "type": "integer",
-      "minimum": 0,
-      "default": 0,
-      "description": "The rate at which feature IDs increment. If `divisor` is 0 then `constant` is used. If `divisor` is non-zero the feature ID increments once per `divisor` sets of elements, starting at `constant`. For example, if `constant` is 0 and `divisor` is 1 the feature IDs are [0, 1, 2, ...]; if `constant` is 2 and `divisor` is 3 the feature IDs are [2, 2, 2, 3, 3, 3, 4, 4, 4, ...]"
-    },
-    "extensions": {},
-    "extras": {}
-  },
-  "not": {
-    "anyOf": [
-      {
-        "required": [
-          "attribute",
-          "constant"
-        ]
-      },
-      {
-        "required": [
-          "attribute",
-          "divisor"
-        ]
-      }
-    ]
-  }
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "featureIdAttribute.featureIds.schema.json",
+	"title": "Feature IDs",
+	"type": "object",
+	"description": "Feature IDs to be used as indices to property arrays in the feature table.",
+	"allOf": [
+		{
+			"$ref": "glTFProperty.schema.json"
+		}
+	],
+	"properties": {
+		"attribute": {
+			"type": "string",
+			"pattern": "^_FEATURE_ID_([1-9]\\d*|0)$",
+			"description": "The name of the attribute containing feature IDs."
+		},
+		"constant": {
+			"type": "integer",
+			"minimum": 0,
+			"default": 0,
+			"description": "Sets a constant feature ID when the attribute property is omitted."
+		},
+		"divisor": {
+			"type": "integer",
+			"minimum": 0,
+			"default": 0,
+			"description": "The rate at which feature IDs increment. If `divisor` is 0 then `constant` is used. If `divisor` is non-zero the feature ID increments once per `divisor` sets of elements, starting at `constant`. For example, if `constant` is 0 and `divisor` is 1 the feature IDs are [0, 1, 2, ...]; if `constant` is 2 and `divisor` is 3 the feature IDs are [2, 2, 2, 3, 3, 3, 4, 4, 4, ...]"
+		},
+		"extensions": {},
+		"extras": {}
+	},
+	"not": {
+		"anyOf": [
+			{
+				"required": [
+					"attribute",
+					"constant"
+				]
+			},
+			{
+				"required": [
+					"attribute",
+					"divisor"
+				]
+			}
+		]
+	}
 }

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdAttribute.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdAttribute.schema.json
@@ -1,32 +1,32 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "featureIdAttribute.schema.json",
-  "title": "Feature ID Attribute",
-  "type": "object",
-  "description": "An object mapping feature IDs to a feature table.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "featureTable": {
-      "type": "string",
-      "description": "The ID of the feature table in the model's root `EXT_feature_metadata.featureTables` dictionary."
-    },
-    "featureIds": {
-      "allOf": [
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "featureIdAttribute.schema.json",
+    "title": "Feature ID Attribute",
+    "type": "object",
+    "description": "An object mapping feature IDs to a feature table.",
+    "allOf": [
         {
-          "$ref": "featureIdAttribute.featureIds.schema.json"
+            "$ref": "glTFProperty.schema.json"
         }
-      ],
-      "description": "An object describing feature IDs to be used as indices to property arrays in the feature table. Feature IDs must be whole numbers in the range `[0, count - 1]` (inclusive), where `count` is the total number of features in the feature table."
+    ],
+    "properties": {
+        "featureTable": {
+            "type": "string",
+            "description": "The ID of the feature table in the model's root `EXT_feature_metadata.featureTables` dictionary."
+        },
+        "featureIds": {
+            "allOf": [
+                {
+                    "$ref": "featureIdAttribute.featureIds.schema.json"
+                }
+            ],
+            "description": "An object describing feature IDs to be used as indices to property arrays in the feature table. Feature IDs must be whole numbers in the range `[0, count - 1]` (inclusive), where `count` is the total number of features in the feature table."
+        },
+        "extensions": {},
+        "extras": {}
     },
-    "extensions": {},
-    "extras": {}
-  },
-  "required": [
-    "featureTable",
-    "featureIds"
-  ]
+    "required": [
+        "featureTable",
+        "featureIds"
+    ]
 }

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdTexture.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureIdTexture.schema.json
@@ -1,32 +1,32 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "featureIdTexture.schema.json",
-  "title": "Feature ID Texture",
-  "type": "object",
-  "description": "An object describing a texture used for storing per-texel feature IDs.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "featureTable": {
-      "type": "string",
-      "description": "The ID of the feature table in the model's root `EXT_feature_metadata.featureTables` dictionary."
-    },
-    "featureIds": {
-      "allOf": [
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "featureIdTexture.schema.json",
+    "title": "Feature ID Texture",
+    "type": "object",
+    "description": "An object describing a texture used for storing per-texel feature IDs.",
+    "allOf": [
         {
-          "$ref": "textureAccessor.schema.json"
+            "$ref": "glTFProperty.schema.json"
         }
-      ],
-      "description": "A description of the texture and channel to use for feature IDs. The `channels` property must have a single channel. Furthermore, feature IDs must be whole numbers in the range `[0, count - 1]` (inclusive), where `count` is the total number of features in the feature table. Texel values must be read as integers. Texture filtering should be disabled when fetching feature IDs."
+    ],
+    "properties": {
+        "featureTable": {
+            "type": "string",
+            "description": "The ID of the feature table in the model's root `EXT_feature_metadata.featureTables` dictionary."
+        },
+        "featureIds": {
+            "allOf": [
+                {
+                    "$ref": "textureAccessor.schema.json"
+                }
+            ],
+            "description": "A description of the texture and channel to use for feature IDs. The `channels` property must have a single channel. Furthermore, feature IDs must be whole numbers in the range `[0, count - 1]` (inclusive), where `count` is the total number of features in the feature table. Texel values must be read as integers. Texture filtering should be disabled when fetching feature IDs."
+        },
+        "extensions": {},
+        "extras": {}
     },
-    "extensions": {},
-    "extras": {}
-  },
-  "required": [
-    "featureTable",
-    "featureIds"
-  ]
+    "required": [
+        "featureTable",
+        "featureIds"
+    ]
 }

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureTable.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureTable.property.schema.json
@@ -1,64 +1,64 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "featureTable.property.schema.json",
-  "title": "Feature Table Property",
-  "type": "object",
-  "description": "An array of binary property values.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "bufferView": {
-      "allOf": [
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "featureTable.property.schema.json",
+    "title": "Feature Table Property",
+    "type": "object",
+    "description": "An array of binary property values.",
+    "allOf": [
         {
-          "$ref": "glTFid.schema.json"
+            "$ref": "glTFProperty.schema.json"
         }
-      ],
-      "description": "The index of the buffer view containing property values. The data type of property values is determined by the property definition: When `type` is `BOOLEAN` values are packed into a bitfield. When `type` is `STRING` values are stored as byte sequences and decoded as UTF-8 strings. When `type` is a numeric type values are stored as the provided `type`. When `type` is `ENUM` values are stored as the enum's `valueType`. Each enum value in the buffer must match one of the allowed values in the enum definition. When `type` is `ARRAY` elements are packed tightly together and the data type is based on the `componentType` following the same rules as above. `arrayOffsetBufferView` is required for variable-size arrays and `stringOffsetBufferView` is required for strings (for variable-length arrays of strings, both are required). The buffer view `byteOffset` must be aligned to a multiple of 8 bytes. If the buffer view's `buffer` is the GLB-stored `BIN` chunk, the byte offset is measured relative to the beginning of the GLB. Otherwise, it is measured relative to the beginning of the buffer."
-    },
-    "offsetType": {
-      "description": "The type of values in `arrayOffsetBufferView` and `stringOffsetBufferView`.",
-      "default": "UINT32",
-      "anyOf": [
-        {
-          "const": "UINT8"
+    ],
+    "properties": {
+        "bufferView": {
+            "allOf": [
+                {
+                    "$ref": "glTFid.schema.json"
+                }
+            ],
+            "description": "The index of the buffer view containing property values. The data type of property values is determined by the property definition: When `type` is `BOOLEAN` values are packed into a bitfield. When `type` is `STRING` values are stored as byte sequences and decoded as UTF-8 strings. When `type` is a numeric type values are stored as the provided `type`. When `type` is `ENUM` values are stored as the enum's `valueType`. Each enum value in the buffer must match one of the allowed values in the enum definition. When `type` is `ARRAY` elements are packed tightly together and the data type is based on the `componentType` following the same rules as above. `arrayOffsetBufferView` is required for variable-size arrays and `stringOffsetBufferView` is required for strings (for variable-length arrays of strings, both are required). The buffer view `byteOffset` must be aligned to a multiple of 8 bytes. If the buffer view's `buffer` is the GLB-stored `BIN` chunk, the byte offset is measured relative to the beginning of the GLB. Otherwise, it is measured relative to the beginning of the buffer."
         },
-        {
-          "const": "UINT16"
+        "offsetType": {
+            "description": "The type of values in `arrayOffsetBufferView` and `stringOffsetBufferView`.",
+            "default": "UINT32",
+            "anyOf": [
+                {
+                    "const": "UINT8"
+                },
+                {
+                    "const": "UINT16"
+                },
+                {
+                    "const": "UINT32"
+                },
+                {
+                    "const": "UINT64"
+                },
+                {
+                    "type": "string"
+                }
+            ]
         },
-        {
-          "const": "UINT32"
+        "arrayOffsetBufferView": {
+            "allOf": [
+                {
+                    "$ref": "glTFid.schema.json"
+                }
+            ],
+            "description": "The index of the buffer view containing offsets for variable-length arrays. The number of offsets is equal to the feature table `count` plus one. The offsets represent the start positions of each array, with the last offset representing the position after the last array. The array length is computed using the difference between the current offset and the subsequent offset. If `componentType` is `STRING` the offsets index into the string offsets array (stored in `stringOffsetBufferView`), otherwise they index into the property array (stored in `bufferView`). The data type of these offsets is determined by `offsetType`. The buffer view `byteOffset` must be aligned to a multiple of 8 bytes in the same manner as the main `bufferView`"
         },
-        {
-          "const": "UINT64"
+        "stringOffsetBufferView": {
+            "allOf": [
+                {
+                    "$ref": "glTFid.schema.json"
+                }
+            ],
+            "description": "The index of the buffer view containing offsets for strings. The number of offsets is equal to the number of string components plus one. The offsets represent the byte offsets of each string in the main `bufferView`, with the last offset representing the byte offset after the last string. The string byte length is computed using the difference between the current offset and the subsequent offset. The data type of these offsets is determined by `offsetType`. The buffer view `byteOffset` must be aligned to a multiple of 8 bytes in the same manner as the main `bufferView`."
         },
-        {
-          "type": "string"
-        }
-      ]
+        "extensions": {},
+        "extras": {}
     },
-    "arrayOffsetBufferView": {
-      "allOf": [
-        {
-          "$ref": "glTFid.schema.json"
-        }
-      ],
-      "description": "The index of the buffer view containing offsets for variable-length arrays. The number of offsets is equal to the feature table `count` plus one. The offsets represent the start positions of each array, with the last offset representing the position after the last array. The array length is computed using the difference between the current offset and the subsequent offset. If `componentType` is `STRING` the offsets index into the string offsets array (stored in `stringOffsetBufferView`), otherwise they index into the property array (stored in `bufferView`). The data type of these offsets is determined by `offsetType`. The buffer view `byteOffset` must be aligned to a multiple of 8 bytes in the same manner as the main `bufferView`"
-    },
-    "stringOffsetBufferView": {
-      "allOf": [
-        {
-          "$ref": "glTFid.schema.json"
-        }
-      ],
-      "description": "The index of the buffer view containing offsets for strings. The number of offsets is equal to the number of string components plus one. The offsets represent the byte offsets of each string in the main `bufferView`, with the last offset representing the byte offset after the last string. The string byte length is computed using the difference between the current offset and the subsequent offset. The data type of these offsets is determined by `offsetType`. The buffer view `byteOffset` must be aligned to a multiple of 8 bytes in the same manner as the main `bufferView`."
-    },
-    "extensions": {},
-    "extras": {}
-  },
-  "required": [
-    "bufferView"
-  ]
+    "required": [
+        "bufferView"
+    ]
 }

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureTable.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureTable.schema.json
@@ -1,36 +1,36 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "featureTable.schema.json",
-  "title": "Feature Table",
-  "type": "object",
-  "description": "A feature table defined by a class and property values stored in arrays.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "class": {
-      "type": "string",
-      "description": "The class that property values conform to. The value must be a class ID declared in the `classes` dictionary."
-    },
-    "count": {
-      "type": "integer",
-      "minimum": 1,
-      "description": "The number of features, as well as the number of elements in each property array."
-    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "featureTable.schema.json",
+    "title": "Feature Table",
+    "type": "object",
+    "description": "A feature table defined by a class and property values stored in arrays.",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
     "properties": {
-      "type": "object",
-      "description": "A dictionary, where each key corresponds to a property ID in the class' `properties` dictionary and each value is an object describing where property values are stored. Optional properties may be excluded from this dictionary.",
-      "minProperties": 1,
-      "additionalProperties": {
-        "$ref": "featureTable.property.schema.json"
-      }
+        "class": {
+            "type": "string",
+            "description": "The class that property values conform to. The value must be a class ID declared in the `classes` dictionary."
+        },
+        "count": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "The number of features, as well as the number of elements in each property array."
+        },
+        "properties": {
+            "type": "object",
+            "description": "A dictionary, where each key corresponds to a property ID in the class' `properties` dictionary and each value is an object describing where property values are stored. Optional properties may be excluded from this dictionary.",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "featureTable.property.schema.json"
+            }
+        },
+        "extensions": {},
+        "extras": {}
     },
-    "extensions": {},
-    "extras": {}
-  },
-  "required": [
-    "count"
-  ]
+    "required": [
+        "count"
+    ]
 }

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureTexture.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/featureTexture.schema.json
@@ -1,32 +1,32 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "featureTexture.schema.json",
-  "title": "Feature Texture",
-  "type": "object",
-  "description": "Features whose property values are stored directly in texture channels. This is not to be confused with feature ID textures which store feature IDs for use with a feature table.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "class": {
-      "type": "string",
-      "description": "The class this feature texture conforms to. The value must be a class ID declared in the `classes` dictionary."
-    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "featureTexture.schema.json",
+    "title": "Feature Texture",
+    "type": "object",
+    "description": "Features whose property values are stored directly in texture channels. This is not to be confused with feature ID textures which store feature IDs for use with a feature table.",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
     "properties": {
-      "type": "object",
-      "description": "A dictionary, where each key corresponds to a property ID in the class' `properties` dictionary and each value describes the texture channels containing property values.",
-      "minProperties": 1,
-      "additionalProperties": {
-        "$ref": "textureAccessor.schema.json"
-      }
+        "class": {
+            "type": "string",
+            "description": "The class this feature texture conforms to. The value must be a class ID declared in the `classes` dictionary."
+        },
+        "properties": {
+            "type": "object",
+            "description": "A dictionary, where each key corresponds to a property ID in the class' `properties` dictionary and each value describes the texture channels containing property values.",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "textureAccessor.schema.json"
+            }
+        },
+        "extensions": {},
+        "extras": {}
     },
-    "extensions": {},
-    "extras": {}
-  },
-  "required": [
-    "class",
-    "properties"
-  ]
+    "required": [
+        "class",
+        "properties"
+    ]
 }

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/glTF.EXT_feature_metadata.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/glTF.EXT_feature_metadata.schema.json
@@ -1,53 +1,53 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "glTF.EXT_feature_metadata.schema.json",
-  "title": "EXT_feature_metadata glTF extension",
-  "type": "object",
-  "description": "glTF extension that assigns metadata to features in a model.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "glTF.EXT_feature_metadata.schema.json",
+    "title": "EXT_feature_metadata glTF extension",
+    "type": "object",
+    "description": "glTF extension that assigns metadata to features in a model.",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "schema": {
+            "allOf": [
+                {
+                    "$ref": "schema.schema.json"
+                }
+            ],
+            "description": "An object defining classes and enums."
+        },
+        "schemaUri": {
+            "type": "string",
+            "description": "The URI (or IRI) of the external schema file.",
+            "format": "iri-reference"
+        },
+        "statistics": {
+            "allOf": [
+                {
+                    "$ref": "statistics.schema.json"
+                }
+            ],
+            "description": "An object containing statistics about features."
+        },
+        "featureTables": {
+            "type": "object",
+            "description": "A dictionary, where each key is a feature table ID and each value is an object defining the feature table.",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "featureTable.schema.json"
+            }
+        },
+        "featureTextures": {
+            "type": "object",
+            "description": "A dictionary, where each key is a feature texture ID and each value is an object defining the feature texture.",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "featureTexture.schema.json"
+            }
+        },
+        "extensions": {},
+        "extras": {}
     }
-  ],
-  "properties": {
-    "schema": {
-      "allOf": [
-        {
-          "$ref": "schema.schema.json"
-        }
-      ],
-      "description": "An object defining classes and enums."
-    },
-    "schemaUri": {
-      "type": "string",
-      "description": "The URI (or IRI) of the external schema file.",
-      "format": "iri-reference"
-    },
-    "statistics": {
-      "allOf": [
-        {
-          "$ref": "statistics.schema.json"
-        }
-      ],
-      "description": "An object containing statistics about features."
-    },
-    "featureTables": {
-      "type": "object",
-      "description": "A dictionary, where each key is a feature table ID and each value is an object defining the feature table.",
-      "minProperties": 1,
-      "additionalProperties": {
-        "$ref": "featureTable.schema.json"
-      }
-    },
-    "featureTextures": {
-      "type": "object",
-      "description": "A dictionary, where each key is a feature texture ID and each value is an object defining the feature texture.",
-      "minProperties": 1,
-      "additionalProperties": {
-        "$ref": "featureTexture.schema.json"
-      }
-    },
-    "extensions": {},
-    "extras": {}
-  }
 }

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/primitive.EXT_feature_metadata.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/primitive.EXT_feature_metadata.schema.json
@@ -1,57 +1,57 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "primitive.EXT_feature_metadata.schema.json",
-  "title": "EXT_feature_metadata glTF Primitive extension",
-  "type": "object",
-  "description": "`EXT_feature_metadata extension` for a primitive in a glTF model, to associate it with the root `EXT_feature_metadata` object.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "featureIdAttributes": {
-      "type": "array",
-      "description": "An array of objects mapping per-vertex feature IDs to a feature table.",
-      "items": {
-        "$ref": "featureIdAttribute.schema.json"
-      },
-      "minItems": 1
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "primitive.EXT_feature_metadata.schema.json",
+    "title": "EXT_feature_metadata glTF Primitive extension",
+    "type": "object",
+    "description": "`EXT_feature_metadata extension` for a primitive in a glTF model, to associate it with the root `EXT_feature_metadata` object.",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "featureIdAttributes": {
+            "type": "array",
+            "description": "An array of objects mapping per-vertex feature IDs to a feature table.",
+            "items": {
+                "$ref": "featureIdAttribute.schema.json"
+            },
+            "minItems": 1
+        },
+        "featureIdTextures": {
+            "type": "array",
+            "description": "An array of objects mapping per-texel feature IDs to a feature table.",
+            "items": {
+                "$ref": "featureIdTexture.schema.json"
+            },
+            "minItems": 1
+        },
+        "featureTextures": {
+            "type": "array",
+            "description": "An array of IDs of feature textures from the root `EXT_feature_metadata` object.",
+            "items": {
+                "type": "string"
+            },
+            "minItems": 1
+        },
+        "extensions": {},
+        "extras": {}
     },
-    "featureIdTextures": {
-      "type": "array",
-      "description": "An array of objects mapping per-texel feature IDs to a feature table.",
-      "items": {
-        "$ref": "featureIdTexture.schema.json"
-      },
-      "minItems": 1
-    },
-    "featureTextures": {
-      "type": "array",
-      "description": "An array of IDs of feature textures from the root `EXT_feature_metadata` object.",
-      "items": {
-        "type": "string"
-      },
-      "minItems": 1
-    },
-    "extensions": {},
-    "extras": {}
-  },
-  "anyOf": [
-    {
-      "required": [
-        "featureIdAttributes"
-      ]
-    },
-    {
-      "required": [
-        "featureIdTextures"
-      ]
-    },
-    {
-      "required": [
-        "featureTextures"
-      ]
-    }
-  ]
+    "anyOf": [
+        {
+            "required": [
+                "featureIdAttributes"
+            ]
+        },
+        {
+            "required": [
+                "featureIdTextures"
+            ]
+        },
+        {
+            "required": [
+                "featureTextures"
+            ]
+        }
+    ]
 }

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/schema.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/schema.schema.json
@@ -1,47 +1,47 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "schema.schema.json",
-  "title": "Schema",
-  "type": "object",
-  "description": "An object defining classes and enums.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "schema.schema.json",
+    "title": "Schema",
+    "type": "object",
+    "description": "An object defining classes and enums.",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the schema."
+        },
+        "description": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The description of the schema."
+        },
+        "version": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Application-specific version of the schema."
+        },
+        "classes": {
+            "type": "object",
+            "description": "A dictionary, where each key is a class ID and each value is an object defining the class.",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "class.schema.json"
+            }
+        },
+        "enums": {
+            "type": "object",
+            "description": "A dictionary, where each key is an enum ID and each value is an object defining the values for the enum.",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "enum.schema.json"
+            }
+        },
+        "extensions": {},
+        "extras": {}
     }
-  ],
-  "properties": {
-    "name": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The name of the schema."
-    },
-    "description": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The description of the schema."
-    },
-    "version": {
-      "type": "string",
-      "minLength": 1,
-      "description": "Application-specific version of the schema."
-    },
-    "classes": {
-      "type": "object",
-      "description": "A dictionary, where each key is a class ID and each value is an object defining the class.",
-      "minProperties": 1,
-      "additionalProperties": {
-        "$ref": "class.schema.json"
-      }
-    },
-    "enums": {
-      "type": "object",
-      "description": "A dictionary, where each key is an enum ID and each value is an object defining the values for the enum.",
-      "minProperties": 1,
-      "additionalProperties": {
-        "$ref": "enum.schema.json"
-      }
-    },
-    "extensions": {},
-    "extras": {}
-  }
 }

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/statistics.class.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/statistics.class.property.schema.json
@@ -1,100 +1,100 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "statistics.class.property.schema.json",
-  "title": "Property Statistics",
-  "type": "object",
-  "description": "Statistics about property values.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "min": {
-      "type": [
-        "number",
-        "array"
-      ],
-      "items": {
-        "type": "number"
-      },
-      "description": "The minimum property value. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values."
-    },
-    "max": {
-      "type": [
-        "number",
-        "array"
-      ],
-      "items": {
-        "type": "number"
-      },
-      "description": "The maximum property value. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values."
-    },
-    "mean": {
-      "type": [
-        "number",
-        "array"
-      ],
-      "items": {
-        "type": "number"
-      },
-      "description": "The arithmetic mean of the property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values."
-    },
-    "median": {
-      "type": [
-        "number",
-        "array"
-      ],
-      "items": {
-        "type": "number"
-      },
-      "description": "The median of the property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values."
-    },
-    "standardDeviation": {
-      "type": [
-        "number",
-        "array"
-      ],
-      "items": {
-        "type": "number"
-      },
-      "description": "The standard deviation of the property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values."
-    },
-    "variance": {
-      "type": [
-        "number",
-        "array"
-      ],
-      "items": {
-        "type": "number"
-      },
-      "description": "The variance of the property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values."
-    },
-    "sum": {
-      "type": [
-        "number",
-        "array"
-      ],
-      "items": {
-        "type": "number"
-      },
-      "description": "The sum of the property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values."
-    },
-    "occurrences": {
-      "type": "object",
-      "description": "A dictionary, where each key corresponds to an enum `name` and each value is the number of occurrences of that enum. Only applicable when `type` or `componentType` is `ENUM`. For fixed-length arrays, this is an array with `componentCount` number of elements.",
-      "minProperties": 1,
-      "additionalProperties": {
-        "type": [
-          "integer",
-          "array"
-        ],
-        "items": {
-          "type": "number"
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "statistics.class.property.schema.json",
+    "title": "Property Statistics",
+    "type": "object",
+    "description": "Statistics about property values.",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
         }
-      }
-    },
-    "extensions": {},
-    "extras": {}
-  }
+    ],
+    "properties": {
+        "min": {
+            "type": [
+                "number",
+                "array"
+            ],
+            "items": {
+                "type": "number"
+            },
+            "description": "The minimum property value. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values."
+        },
+        "max": {
+            "type": [
+                "number",
+                "array"
+            ],
+            "items": {
+                "type": "number"
+            },
+            "description": "The maximum property value. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values."
+        },
+        "mean": {
+            "type": [
+                "number",
+                "array"
+            ],
+            "items": {
+                "type": "number"
+            },
+            "description": "The arithmetic mean of the property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values."
+        },
+        "median": {
+            "type": [
+                "number",
+                "array"
+            ],
+            "items": {
+                "type": "number"
+            },
+            "description": "The median of the property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values."
+        },
+        "standardDeviation": {
+            "type": [
+                "number",
+                "array"
+            ],
+            "items": {
+                "type": "number"
+            },
+            "description": "The standard deviation of the property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values."
+        },
+        "variance": {
+            "type": [
+                "number",
+                "array"
+            ],
+            "items": {
+                "type": "number"
+            },
+            "description": "The variance of the property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values."
+        },
+        "sum": {
+            "type": [
+                "number",
+                "array"
+            ],
+            "items": {
+                "type": "number"
+            },
+            "description": "The sum of the property values. Only applicable for numeric types and fixed-length arrays of numeric types. For numeric types this is a single number. For fixed-length arrays this is an array with `componentCount` number of elements. The `normalized` property has no effect on these values."
+        },
+        "occurrences": {
+            "type": "object",
+            "description": "A dictionary, where each key corresponds to an enum `name` and each value is the number of occurrences of that enum. Only applicable when `type` or `componentType` is `ENUM`. For fixed-length arrays, this is an array with `componentCount` number of elements.",
+            "minProperties": 1,
+            "additionalProperties": {
+                "type": [
+                    "integer",
+                    "array"
+                ],
+                "items": {
+                    "type": "number"
+                }
+            }
+        },
+        "extensions": {},
+        "extras": {}
+    }
 }

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/statistics.class.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/statistics.class.schema.json
@@ -1,29 +1,29 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "statistics.class.schema.json",
-  "title": "Class Statistics",
-  "type": "object",
-  "description": "Statistics about features that conform to the class.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "count": {
-      "type": "integer",
-      "description": "The number of features that conform to the class.",
-      "minimum": 0
-    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "statistics.class.schema.json",
+    "title": "Class Statistics",
+    "type": "object",
+    "description": "Statistics about features that conform to the class.",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
     "properties": {
-      "type": "object",
-      "description": "A dictionary, where each key corresponds to a property ID in the class' `properties` dictionary and each value is an object containing statistics about property values.",
-      "minProperties": 1,
-      "additionalProperties": {
-        "$ref": "statistics.class.property.schema.json"
-      }
-    },
-    "extensions": {},
-    "extras": {}
-  }
+        "count": {
+            "type": "integer",
+            "description": "The number of features that conform to the class.",
+            "minimum": 0
+        },
+        "properties": {
+            "type": "object",
+            "description": "A dictionary, where each key corresponds to a property ID in the class' `properties` dictionary and each value is an object containing statistics about property values.",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "statistics.class.property.schema.json"
+            }
+        },
+        "extensions": {},
+        "extras": {}
+    }
 }

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/statistics.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/statistics.schema.json
@@ -1,24 +1,24 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "statistics.schema.json",
-  "title": "Statistics",
-  "type": "object",
-  "description": "Statistics about features.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "statistics.schema.json",
+    "title": "Statistics",
+    "type": "object",
+    "description": "Statistics about features.",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "classes": {
+            "type": "object",
+            "description": "A dictionary, where each key is a class ID declared in the `classes` dictionary and each value is an object containing statistics about features that conform to the class.",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "statistics.class.schema.json"
+            }
+        },
+        "extensions": {},
+        "extras": {}
     }
-  ],
-  "properties": {
-    "classes": {
-      "type": "object",
-      "description": "A dictionary, where each key is a class ID declared in the `classes` dictionary and each value is an object containing statistics about features that conform to the class.",
-      "minProperties": 1,
-      "additionalProperties": {
-        "$ref": "statistics.class.schema.json"
-      }
-    },
-    "extensions": {},
-    "extras": {}
-  }
 }

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/textureAccessor.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/textureAccessor.schema.json
@@ -1,33 +1,33 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "textureAccessor.schema.json",
-  "title": "Texture Accessor",
-  "type": "object",
-  "description": "A description of how to access property values from the color channels of a texture.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "channels": {
-      "type": "string",
-      "pattern": "^[rgba]{1,4}$",
-      "description": "Texture channels containing property values. Channels are labeled by `rgba` and are swizzled with a string of 1-4 characters."
-    },
-    "texture": {
-      "allOf": [
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "textureAccessor.schema.json",
+    "title": "Texture Accessor",
+    "type": "object",
+    "description": "A description of how to access property values from the color channels of a texture.",
+    "allOf": [
         {
-          "$ref": "textureInfo.schema.json"
+            "$ref": "glTFProperty.schema.json"
         }
-      ],
-      "description": "The glTF texture and texture coordinates to use."
+    ],
+    "properties": {
+        "channels": {
+            "type": "string",
+            "pattern": "^[rgba]{1,4}$",
+            "description": "Texture channels containing property values. Channels are labeled by `rgba` and are swizzled with a string of 1-4 characters."
+        },
+        "texture": {
+            "allOf": [
+                {
+                    "$ref": "textureInfo.schema.json"
+                }
+            ],
+            "description": "The glTF texture and texture coordinates to use."
+        },
+        "extensions": {},
+        "extras": {}
     },
-    "extensions": {},
-    "extras": {}
-  },
-  "required": [
-    "channels",
-    "texture"
-  ]
+    "required": [
+        "channels",
+        "texture"
+    ]
 }

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/class.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/class.property.schema.json
@@ -1,193 +1,193 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "class.property.schema.json",
-  "title": "Property",
-  "type": "object",
-  "description": "A class property.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "name": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The name of the property, e.g. for display purposes."
-    },
-    "description": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The description of the property."
-    },
-    "type": {
-      "description": "Element type represented by each property value. `VECN` is a vector of `N` numeric components. `MATN` is an `N ⨉ N` matrix of numeric components stored in column-major order. `ARRAY` is fixed-length when `componentCount` is defined, and is variable-length otherwise.",
-      "default": "SINGLE",
-      "anyOf": [
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "class.property.schema.json",
+    "title": "Property",
+    "type": "object",
+    "description": "A class property.",
+    "allOf": [
         {
-          "const": "SINGLE"
-        },
-        {
-          "const": "VEC2"
-        },
-        {
-          "const": "VEC3"
-        },
-        {
-          "const": "VEC4"
-        },
-        {
-          "const": "MAT2"
-        },
-        {
-          "const": "MAT3"
-        },
-        {
-          "const": "MAT4"
-        },
-        {
-          "const": "ARRAY"
-        },
-        {
-          "type": "string"
+            "$ref": "glTFProperty.schema.json"
         }
-      ]
+    ],
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the property, e.g. for display purposes."
+        },
+        "description": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The description of the property."
+        },
+        "type": {
+            "description": "Element type represented by each property value. `VECN` is a vector of `N` numeric components. `MATN` is an `N ⨉ N` matrix of numeric components stored in column-major order. `ARRAY` is fixed-length when `componentCount` is defined, and is variable-length otherwise.",
+            "default": "SINGLE",
+            "anyOf": [
+                {
+                    "const": "SINGLE"
+                },
+                {
+                    "const": "VEC2"
+                },
+                {
+                    "const": "VEC3"
+                },
+                {
+                    "const": "VEC4"
+                },
+                {
+                    "const": "MAT2"
+                },
+                {
+                    "const": "MAT3"
+                },
+                {
+                    "const": "MAT4"
+                },
+                {
+                    "const": "ARRAY"
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        },
+        "enumType": {
+            "type": "string",
+            "description": "Enum ID as declared in the `enums` dictionary. Required when `componentType` is `ENUM`."
+        },
+        "componentType": {
+            "description": "Data type of an element's components. When `type` is `SINGLE`, then `componentType` is also the data type of the element. When `componentType` is `ENUM`, `enumType` is required.",
+            "anyOf": [
+                {
+                    "const": "INT8"
+                },
+                {
+                    "const": "UINT8"
+                },
+                {
+                    "const": "INT16"
+                },
+                {
+                    "const": "UINT16"
+                },
+                {
+                    "const": "INT32"
+                },
+                {
+                    "const": "UINT32"
+                },
+                {
+                    "const": "INT64"
+                },
+                {
+                    "const": "UINT64"
+                },
+                {
+                    "const": "FLOAT32"
+                },
+                {
+                    "const": "FLOAT64"
+                },
+                {
+                    "const": "BOOLEAN"
+                },
+                {
+                    "const": "STRING"
+                },
+                {
+                    "const": "ENUM"
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        },
+        "componentCount": {
+            "type": "integer",
+            "minimum": 2,
+            "description": "Number of components per element for fixed-length `ARRAY` elements. Always undefined for variable-length `ARRAY` and all other element types."
+        },
+        "normalized": {
+            "type": "boolean",
+            "description": "Specifies whether integer values are normalized. This applies when `componentType` is an integer type. For unsigned integer component types, values are normalized between `[0.0, 1.0]`. For signed integer component types, values are normalized between `[-1.0, 1.0]`. For all other component types, this property must be false.",
+            "default": false
+        },
+        "max": {
+            "oneOf": [
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    },
+                    "minItems": 1
+                }
+            ],
+            "description": "Maximum allowed value for the property. Only applicable for single-value numeric types, fixed-length arrays of numeric types, `VECN`, and `MATN` types. For single-value numeric types this is a single number. For fixed-length arrays, `VECN`, and `MATN` types, this is an array of component-wise maximum values. The `normalized` property has no effect on the maximum, which always contains integer values."
+        },
+        "min": {
+            "oneOf": [
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    },
+                    "minItems": 1
+                }
+            ],
+            "description": "Minimum allowed value for the property. Only applicable for single-value numeric types, fixed-length arrays of numeric types, `VECN`, and `MATN` types. For single-value numeric types this is a single number. For fixed-length arrays, `VECN`, and `MATN` types, this is an array of component-wise minimum values. The `normalized` property has no effect on the minimum, which always contains integer values."
+        },
+        "required": {
+            "type": "boolean",
+            "description": "If required, the property must be present for every feature of its class. If not required, individual features may include `noData` values, or the entire property may be omitted from a property table or texture. As a result, `noData` has no effect on a required property. Client implementations may use required properties to make performance optimizations.",
+            "default": false
+        },
+        "noData": {
+            "oneOf": [
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    },
+                    "minItems": 1
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1
+                }
+            ],
+            "description": "A `noData` value represents missing data — also known as a sentinel value — wherever it appears. If omitted (excluding variable-length `ARRAY` properties), property values exist for all features, and the property is required in property tables or textures instantiating the class. For variable-length `ARRAY` elements, `noData` is implicitly `[]` and the property is never required; an additional `noData` array, such as `[\"UNSPECIFIED\"]`, may be provided if necessary. For fixed-length `ARRAY` properties, `noData` must be an array of length `componentCount`. For `VECN` properties, `noData` must be an array of length `N`. For `MATN` propperties, `noData` must be an array of length `N²`. `BOOLEAN` properties may not specify `noData` values. `ENUM` `noData` values must use a valid enum `name`, not an integer value."
+        },
+        "semantic": {
+            "type": "string",
+            "minLength": 1,
+            "description": "An identifier that describes how this property should be interpreted. The semantic cannot be used by other properties in the class."
+        },
+        "extensions": {},
+        "extras": {}
     },
-    "enumType": {
-      "type": "string",
-      "description": "Enum ID as declared in the `enums` dictionary. Required when `componentType` is `ENUM`."
+    "dependencies": {
+        "componentCount": [
+            "type"
+        ]
     },
-    "componentType": {
-      "description": "Data type of an element's components. When `type` is `SINGLE`, then `componentType` is also the data type of the element. When `componentType` is `ENUM`, `enumType` is required.",
-      "anyOf": [
-        {
-          "const": "INT8"
-        },
-        {
-          "const": "UINT8"
-        },
-        {
-          "const": "INT16"
-        },
-        {
-          "const": "UINT16"
-        },
-        {
-          "const": "INT32"
-        },
-        {
-          "const": "UINT32"
-        },
-        {
-          "const": "INT64"
-        },
-        {
-          "const": "UINT64"
-        },
-        {
-          "const": "FLOAT32"
-        },
-        {
-          "const": "FLOAT64"
-        },
-        {
-          "const": "BOOLEAN"
-        },
-        {
-          "const": "STRING"
-        },
-        {
-          "const": "ENUM"
-        },
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "componentCount": {
-      "type": "integer",
-      "minimum": 2,
-      "description": "Number of components per element for fixed-length `ARRAY` elements. Always undefined for variable-length `ARRAY` and all other element types."
-    },
-    "normalized": {
-      "type": "boolean",
-      "description": "Specifies whether integer values are normalized. This applies when `componentType` is an integer type. For unsigned integer component types, values are normalized between `[0.0, 1.0]`. For signed integer component types, values are normalized between `[-1.0, 1.0]`. For all other component types, this property must be false.",
-      "default": false
-    },
-    "max": {
-      "oneOf": [
-        {
-          "type": "number"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "number"
-          },
-          "minItems": 1
-        }
-      ],
-      "description": "Maximum allowed value for the property. Only applicable for single-value numeric types, fixed-length arrays of numeric types, `VECN`, and `MATN` types. For single-value numeric types this is a single number. For fixed-length arrays, `VECN`, and `MATN` types, this is an array of component-wise maximum values. The `normalized` property has no effect on the maximum, which always contains integer values."
-    },
-    "min": {
-      "oneOf": [
-        {
-          "type": "number"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "number"
-          },
-          "minItems": 1
-        }
-      ],
-      "description": "Minimum allowed value for the property. Only applicable for single-value numeric types, fixed-length arrays of numeric types, `VECN`, and `MATN` types. For single-value numeric types this is a single number. For fixed-length arrays, `VECN`, and `MATN` types, this is an array of component-wise minimum values. The `normalized` property has no effect on the minimum, which always contains integer values."
-    },
-    "required": {
-      "type": "boolean",
-      "description": "If required, the property must be present for every feature of its class. If not required, individual features may include `noData` values, or the entire property may be omitted from a property table or texture. As a result, `noData` has no effect on a required property. Client implementations may use required properties to make performance optimizations.",
-      "default": false
-    },
-    "noData": {
-      "oneOf": [
-        {
-          "type": "number"
-        },
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "number"
-          },
-          "minItems": 1
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "minItems": 1
-        }
-      ],
-      "description": "A `noData` value represents missing data — also known as a sentinel value — wherever it appears. If omitted (excluding variable-length `ARRAY` properties), property values exist for all features, and the property is required in property tables or textures instantiating the class. For variable-length `ARRAY` elements, `noData` is implicitly `[]` and the property is never required; an additional `noData` array, such as `[\"UNSPECIFIED\"]`, may be provided if necessary. For fixed-length `ARRAY` properties, `noData` must be an array of length `componentCount`. For `VECN` properties, `noData` must be an array of length `N`. For `MATN` propperties, `noData` must be an array of length `N²`. `BOOLEAN` properties may not specify `noData` values. `ENUM` `noData` values must use a valid enum `name`, not an integer value."
-    },
-    "semantic": {
-      "type": "string",
-      "minLength": 1,
-      "description": "An identifier that describes how this property should be interpreted. The semantic cannot be used by other properties in the class."
-    },
-    "extensions": {},
-    "extras": {}
-  },
-  "dependencies": {
-    "componentCount": [
-      "type"
+    "required": [
+        "componentType"
     ]
-  },
-  "required": [
-    "componentType"
-  ]
 }

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/class.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/class.schema.json
@@ -1,34 +1,34 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "class.schema.json",
-  "title": "Class",
-  "type": "object",
-  "description": "A class containing a set of properties.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "name": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The name of the class, e.g. for display purposes."
-    },
-    "description": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The description of the class."
-    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "class.schema.json",
+    "title": "Class",
+    "type": "object",
+    "description": "A class containing a set of properties.",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
     "properties": {
-      "type": "object",
-      "description": "A dictionary, where each key is a property ID and each value is an object defining the property. Property IDs may contain only alphanumeric and underscore characters.",
-      "minProperties": 1,
-      "additionalProperties": {
-        "$ref": "class.property.schema.json"
-      }
-    },
-    "extensions": {},
-    "extras": {}
-  }
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the class, e.g. for display purposes."
+        },
+        "description": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The description of the class."
+        },
+        "properties": {
+            "type": "object",
+            "description": "A dictionary, where each key is a property ID and each value is an object defining the property. Property IDs may contain only alphanumeric and underscore characters.",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "class.property.schema.json"
+            }
+        },
+        "extensions": {},
+        "extras": {}
+    }
 }

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/enum.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/enum.schema.json
@@ -1,70 +1,70 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "enum.schema.json",
-  "title": "Enum",
-  "type": "object",
-  "description": "An object defining the values of an enum.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "name": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The name of the enum, e.g. for display purposes."
-    },
-    "description": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The description of the enum."
-    },
-    "valueType": {
-      "default": "UINT16",
-      "description": "The type of the integer enum value.",
-      "anyOf": [
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "enum.schema.json",
+    "title": "Enum",
+    "type": "object",
+    "description": "An object defining the values of an enum.",
+    "allOf": [
         {
-          "const": "INT8"
-        },
-        {
-          "const": "UINT8"
-        },
-        {
-          "const": "INT16"
-        },
-        {
-          "const": "UINT16"
-        },
-        {
-          "const": "INT32"
-        },
-        {
-          "const": "UINT32"
-        },
-        {
-          "const": "INT64"
-        },
-        {
-          "const": "UINT64"
-        },
-        {
-          "type": "string"
+            "$ref": "glTFProperty.schema.json"
         }
-      ]
+    ],
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the enum, e.g. for display purposes."
+        },
+        "description": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The description of the enum."
+        },
+        "valueType": {
+            "default": "UINT16",
+            "description": "The type of the integer enum value.",
+            "anyOf": [
+                {
+                    "const": "INT8"
+                },
+                {
+                    "const": "UINT8"
+                },
+                {
+                    "const": "INT16"
+                },
+                {
+                    "const": "UINT16"
+                },
+                {
+                    "const": "INT32"
+                },
+                {
+                    "const": "UINT32"
+                },
+                {
+                    "const": "INT64"
+                },
+                {
+                    "const": "UINT64"
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        },
+        "values": {
+            "type": "array",
+            "description": "An array of enum values. Duplicate names or duplicate integer values are not allowed.",
+            "items": {
+                "$ref": "enum.value.schema.json"
+            },
+            "minItems": 1
+        },
+        "extensions": {},
+        "extras": {}
     },
-    "values": {
-      "type": "array",
-      "description": "An array of enum values. Duplicate names or duplicate integer values are not allowed.",
-      "items": {
-        "$ref": "enum.value.schema.json"
-      },
-      "minItems": 1
-    },
-    "extensions": {},
-    "extras": {}
-  },
-  "required": [
-    "values"
-  ]
+    "required": [
+        "values"
+    ]
 }

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/enum.value.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/enum.value.schema.json
@@ -1,34 +1,34 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "enum.value.schema.json",
-  "title": "Enum value",
-  "type": "object",
-  "description": "An enum value.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "name": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The name of the enum value."
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "enum.value.schema.json",
+    "title": "Enum value",
+    "type": "object",
+    "description": "An enum value.",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the enum value."
+        },
+        "description": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The description of the enum value."
+        },
+        "value": {
+            "type": "integer",
+            "description": "The integer enum value."
+        },
+        "extensions": {},
+        "extras": {}
     },
-    "description": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The description of the enum value."
-    },
-    "value": {
-      "type": "integer",
-      "description": "The integer enum value."
-    },
-    "extensions": {},
-    "extras": {}
-  },
-  "required": [
-    "name",
-    "value"
-  ]
+    "required": [
+        "name",
+        "value"
+    ]
 }

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/featureIdAttribute.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/featureIdAttribute.schema.json
@@ -1,62 +1,62 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "featureIdAttribute.schema.json",
-  "title": "Feature ID Attribute",
-  "type": "object",
-  "description": "Feature IDs to be used as indices to property arrays in the property table.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "attribute": {
-      "type": "integer",
-      "minimum": 0,
-      "description": "This integer value is used to construct a string in the format `FEATURE_ID_<set index>` which is a reference to a key in `mesh.primitives.attributes` (e.g. a value of `0` corresponds to `FEATURE_ID_0`)."
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "featureIdAttribute.schema.json",
+    "title": "Feature ID Attribute",
+    "type": "object",
+    "description": "Feature IDs to be used as indices to property arrays in the property table.",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "attribute": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "This integer value is used to construct a string in the format `FEATURE_ID_<set index>` which is a reference to a key in `mesh.primitives.attributes` (e.g. a value of `0` corresponds to `FEATURE_ID_0`)."
+        },
+        "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": "Initial value for an implicit feature ID range."
+        },
+        "repeat": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Number of vertices for which to repeat each feature ID before incrementing the ID by 1. If `repeat` is undefined, the feature ID for all vertices is `offset`."
+        },
+        "extensions": {},
+        "extras": {}
     },
-    "offset": {
-      "type": "integer",
-      "minimum": 0,
-      "default": 0,
-      "description": "Initial value for an implicit feature ID range."
-    },
-    "repeat": {
-      "type": "integer",
-      "minimum": 1,
-      "description": "Number of vertices for which to repeat each feature ID before incrementing the ID by 1. If `repeat` is undefined, the feature ID for all vertices is `offset`."
-    },
-    "extensions": {},
-    "extras": {}
-  },
-  "oneOf": [
-    {
-      "description": "Explicit feature ID. 'attribute' is required; 'offset' and 'repeat' are disallowed.",
-      "required": [
-        "attribute"
-      ],
-      "not": {
-        "anyOf": [
-          {
+    "oneOf": [
+        {
+            "description": "Explicit feature ID. 'attribute' is required; 'offset' and 'repeat' are disallowed.",
             "required": [
-              "offset"
-            ]
-          },
-          {
-            "required": [
-              "repeat"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "description": "Implicit feature ID. Both 'offset' and 'repeat' are optional; 'attribute' is disallowed.",
-      "not": {
-        "required": [
-          "attribute"
-        ]
-      }
-    }
-  ]
+                "attribute"
+            ],
+            "not": {
+                "anyOf": [
+                    {
+                        "required": [
+                            "offset"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "repeat"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "description": "Implicit feature ID. Both 'offset' and 'repeat' are optional; 'attribute' is disallowed.",
+            "not": {
+                "required": [
+                    "attribute"
+                ]
+            }
+        }
+    ]
 }

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/featureIdTexture.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/featureIdTexture.schema.json
@@ -1,26 +1,26 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "featureIdTexture.schema.json",
-  "title": "Feature ID Texture",
-  "type": "object",
-  "description": "An object describing a texture used for storing per-texel feature IDs.",
-  "allOf": [
-    {
-      "$ref": "textureInfo.schema.json"
-    }
-  ],
-  "properties": {
-    "index": {},
-    "texCoord": {},
-    "channel": {
-      "type": "integer",
-      "minimum": 0,
-      "description": "Single channel index storing per-texel feature IDs."
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "featureIdTexture.schema.json",
+    "title": "Feature ID Texture",
+    "type": "object",
+    "description": "An object describing a texture used for storing per-texel feature IDs.",
+    "allOf": [
+        {
+            "$ref": "textureInfo.schema.json"
+        }
+    ],
+    "properties": {
+        "index": {},
+        "texCoord": {},
+        "channel": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Single channel index storing per-texel feature IDs."
+        },
+        "extensions": {},
+        "extras": {}
     },
-    "extensions": {},
-    "extras": {}
-  },
-  "required": [
-    "channel"
-  ]
+    "required": [
+        "channel"
+    ]
 }

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/glTF.EXT_mesh_features.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/glTF.EXT_mesh_features.schema.json
@@ -1,63 +1,63 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "glTF.EXT_mesh_features.schema.json",
-  "title": "EXT_mesh_features glTF extension",
-  "type": "object",
-  "description": "glTF extension that assigns properties to features in a model.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "schema": {
-      "allOf": [
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "glTF.EXT_mesh_features.schema.json",
+    "title": "EXT_mesh_features glTF extension",
+    "type": "object",
+    "description": "glTF extension that assigns properties to features in a model.",
+    "allOf": [
         {
-          "$ref": "schema.schema.json"
+            "$ref": "glTFProperty.schema.json"
         }
-      ],
-      "description": "An object defining classes and enums."
+    ],
+    "properties": {
+        "schema": {
+            "allOf": [
+                {
+                    "$ref": "schema.schema.json"
+                }
+            ],
+            "description": "An object defining classes and enums."
+        },
+        "schemaUri": {
+            "type": "string",
+            "description": "The URI (or IRI) of the external schema file.",
+            "format": "iri-reference"
+        },
+        "propertyTables": {
+            "type": "array",
+            "description": "An array of property table definitions, which may be referenced by index.",
+            "minItems": 1,
+            "items": {
+                "$ref": "propertyTable.schema.json"
+            }
+        },
+        "propertyTextures": {
+            "type": "array",
+            "description": "An array of property texture definitions, which may be referenced by index.",
+            "minItems": 1,
+            "items": {
+                "$ref": "propertyTexture.schema.json"
+            }
+        },
+        "extensions": {},
+        "extras": {}
     },
-    "schemaUri": {
-      "type": "string",
-      "description": "The URI (or IRI) of the external schema file.",
-      "format": "iri-reference"
-    },
-    "propertyTables": {
-      "type": "array",
-      "description": "An array of property table definitions, which may be referenced by index.",
-      "minItems": 1,
-      "items": {
-        "$ref": "propertyTable.schema.json"
-      }
-    },
-    "propertyTextures": {
-      "type": "array",
-      "description": "An array of property texture definitions, which may be referenced by index.",
-      "minItems": 1,
-      "items": {
-        "$ref": "propertyTexture.schema.json"
-      }
-    },
-    "extensions": {},
-    "extras": {}
-  },
-  "oneOf": [
-    {
-      "description": "External schema, if any.",
-      "not": {
-        "required": [
-          "schema"
-        ]
-      }
-    },
-    {
-      "description": "Internal schema, if any.",
-      "not": {
-        "required": [
-          "schemaUri"
-        ]
-      }
-    }
-  ]
+    "oneOf": [
+        {
+            "description": "External schema, if any.",
+            "not": {
+                "required": [
+                    "schema"
+                ]
+            }
+        },
+        {
+            "description": "Internal schema, if any.",
+            "not": {
+                "required": [
+                    "schemaUri"
+                ]
+            }
+        }
+    ]
 }

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/node.EXT_mesh_features.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/node.EXT_mesh_features.schema.json
@@ -1,39 +1,39 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "node.EXT_mesh_features.schema.json",
-  "title": "EXT_mesh_features extension for EXT_mesh_gpu_instancing",
-  "type": "object",
-  "description": "An object describing per-instance feature IDs to be used as indices to property arrays in the property table.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "featureIds": {
-      "type": "array",
-      "description": "",
-      "items": {
-        "$ref": "featureIdAttribute.schema.json"
-      },
-      "minItems": 1
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "node.EXT_mesh_features.schema.json",
+    "title": "EXT_mesh_features extension for EXT_mesh_gpu_instancing",
+    "type": "object",
+    "description": "An object describing per-instance feature IDs to be used as indices to property arrays in the property table.",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "featureIds": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "$ref": "featureIdAttribute.schema.json"
+            },
+            "minItems": 1
+        },
+        "propertyTables": {
+            "type": "array",
+            "description": "An array of IDs of property tables from the root `EXT_mesh_features` object.",
+            "items": {
+                "allOf": [
+                    {
+                        "$ref": "glTFid.schema.json"
+                    }
+                ]
+            },
+            "minItems": 1
+        },
+        "extensions": {},
+        "extras": {}
     },
-    "propertyTables": {
-      "type": "array",
-      "description": "An array of IDs of property tables from the root `EXT_mesh_features` object.",
-      "items": {
-        "allOf": [
-          {
-            "$ref": "glTFid.schema.json"
-          }
-        ]
-      },
-      "minItems": 1
-    },
-    "extensions": {},
-    "extras": {}
-  },
-  "required": [
-    "featureIds"
-  ]
+    "required": [
+        "featureIds"
+    ]
 }

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/primitive.EXT_mesh_features.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/primitive.EXT_mesh_features.schema.json
@@ -1,67 +1,67 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "primitive.EXT_mesh_features.schema.json",
-  "title": "EXT_mesh_features glTF Primitive extension",
-  "type": "object",
-  "description": "`EXT_mesh_features` extension for a primitive in a glTF model, to associate it with the root `EXT_mesh_features` object.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "featureIds": {
-      "type": "array",
-      "description": "An array of feature IDs. A property table at index `i` corresponds to the `featureIds` entry at the same index. Additional feature ID entries may be present, so the length of the `featureIds` array must be greater than or equal to the length of the `propertyTables` array.",
-      "items": {
-        "oneOf": [
-          {
-            "$ref": "featureIdAttribute.schema.json"
-          },
-          {
-            "$ref": "featureIdTexture.schema.json"
-          }
-        ]
-      },
-      "minItems": 1
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "primitive.EXT_mesh_features.schema.json",
+    "title": "EXT_mesh_features glTF Primitive extension",
+    "type": "object",
+    "description": "`EXT_mesh_features` extension for a primitive in a glTF model, to associate it with the root `EXT_mesh_features` object.",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "featureIds": {
+            "type": "array",
+            "description": "An array of feature IDs. A property table at index `i` corresponds to the `featureIds` entry at the same index. Additional feature ID entries may be present, so the length of the `featureIds` array must be greater than or equal to the length of the `propertyTables` array.",
+            "items": {
+                "oneOf": [
+                    {
+                        "$ref": "featureIdAttribute.schema.json"
+                    },
+                    {
+                        "$ref": "featureIdTexture.schema.json"
+                    }
+                ]
+            },
+            "minItems": 1
+        },
+        "propertyTables": {
+            "type": "array",
+            "description": "An array of IDs of property tables from the root `EXT_mesh_features` object. A property table at index `i` corresponds to the `featureIds` entry at the same index.",
+            "items": {
+                "allOf": [
+                    {
+                        "$ref": "glTFid.schema.json"
+                    }
+                ]
+            },
+            "minItems": 1
+        },
+        "propertyTextures": {
+            "type": "array",
+            "description": "An array of IDs of property textures from the root `EXT_mesh_features` object.",
+            "items": {
+                "allOf": [
+                    {
+                        "$ref": "glTFid.schema.json"
+                    }
+                ]
+            },
+            "minItems": 1
+        },
+        "extensions": {},
+        "extras": {}
     },
-    "propertyTables": {
-      "type": "array",
-      "description": "An array of IDs of property tables from the root `EXT_mesh_features` object. A property table at index `i` corresponds to the `featureIds` entry at the same index.",
-      "items": {
-        "allOf": [
-          {
-            "$ref": "glTFid.schema.json"
-          }
-        ]
-      },
-      "minItems": 1
-    },
-    "propertyTextures": {
-      "type": "array",
-      "description": "An array of IDs of property textures from the root `EXT_mesh_features` object.",
-      "items": {
-        "allOf": [
-          {
-            "$ref": "glTFid.schema.json"
-          }
-        ]
-      },
-      "minItems": 1
-    },
-    "extensions": {},
-    "extras": {}
-  },
-  "anyOf": [
-    {
-      "required": [
-        "featureIds"
-      ]
-    },
-    {
-      "required": [
-        "propertyTextures"
-      ]
-    }
-  ]
+    "anyOf": [
+        {
+            "required": [
+                "featureIds"
+            ]
+        },
+        {
+            "required": [
+                "propertyTextures"
+            ]
+        }
+    ]
 }

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/propertyTable.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/propertyTable.property.schema.json
@@ -1,85 +1,85 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "propertyTable.property.schema.json",
-  "title": "Property Table Property",
-  "type": "object",
-  "description": "An array of binary property values.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "bufferView": {
-      "allOf": [
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "propertyTable.property.schema.json",
+    "title": "Property Table Property",
+    "type": "object",
+    "description": "An array of binary property values.",
+    "allOf": [
         {
-          "$ref": "glTFid.schema.json"
+            "$ref": "glTFProperty.schema.json"
         }
-      ],
-      "description": "The index of the buffer view containing property values. The data type of property values is determined by the property definition: When `componentType` is `BOOLEAN` values are packed into a bitstream. When `componentType` is `STRING` values are stored as byte sequences and decoded as UTF-8 strings. When `componentType` is a numeric type values are stored as the provided `componentType`. When `componentType` is `ENUM` values are stored as the enum's `valueType`. Each enum value in the buffer must match one of the allowed values in the enum definition. When `type` is `ARRAY` elements are packed tightly together and the data type is based on the `componentType` following the same rules as above. `arrayOffsetBufferView` is required for variable-size arrays and `stringOffsetBufferView` is required for strings (for variable-length arrays of strings, both are required). The buffer view `byteOffset` must be aligned to a multiple of the `componentType` size."
+    ],
+    "properties": {
+        "bufferView": {
+            "allOf": [
+                {
+                    "$ref": "glTFid.schema.json"
+                }
+            ],
+            "description": "The index of the buffer view containing property values. The data type of property values is determined by the property definition: When `componentType` is `BOOLEAN` values are packed into a bitstream. When `componentType` is `STRING` values are stored as byte sequences and decoded as UTF-8 strings. When `componentType` is a numeric type values are stored as the provided `componentType`. When `componentType` is `ENUM` values are stored as the enum's `valueType`. Each enum value in the buffer must match one of the allowed values in the enum definition. When `type` is `ARRAY` elements are packed tightly together and the data type is based on the `componentType` following the same rules as above. `arrayOffsetBufferView` is required for variable-size arrays and `stringOffsetBufferView` is required for strings (for variable-length arrays of strings, both are required). The buffer view `byteOffset` must be aligned to a multiple of the `componentType` size."
+        },
+        "arrayOffsetType": {
+            "description": "The type of values in `arrayOffsetBufferView`.",
+            "default": "UINT32",
+            "anyOf": [
+                {
+                    "const": "UINT8"
+                },
+                {
+                    "const": "UINT16"
+                },
+                {
+                    "const": "UINT32"
+                },
+                {
+                    "const": "UINT64"
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        },
+        "arrayOffsetBufferView": {
+            "allOf": [
+                {
+                    "$ref": "glTFid.schema.json"
+                }
+            ],
+            "description": "The index of the buffer view containing offsets for variable-length arrays. The number of offsets is equal to the property table `count` plus one. The offsets represent the start positions of each array, with the last offset representing the position after the last array. The array length is computed using the difference between the current offset and the subsequent offset. If `componentType` is `STRING` the offsets index into the string offsets array (stored in `stringOffsetBufferView`), otherwise they index into the property array (stored in `bufferView`). The data type of these offsets is determined by `arrayOffsetType`. The buffer view `byteOffset` must be aligned to a multiple of the `arrayOffsetType` size."
+        },
+        "stringOffsetType": {
+            "description": "The type of values in `stringOffsetBufferView`.",
+            "default": "UINT32",
+            "anyOf": [
+                {
+                    "const": "UINT8"
+                },
+                {
+                    "const": "UINT16"
+                },
+                {
+                    "const": "UINT32"
+                },
+                {
+                    "const": "UINT64"
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        },
+        "stringOffsetBufferView": {
+            "allOf": [
+                {
+                    "$ref": "glTFid.schema.json"
+                }
+            ],
+            "description": "The index of the buffer view containing offsets for strings. The number of offsets is equal to the number of string components plus one. The offsets represent the byte offsets of each string in the main `bufferView`, with the last offset representing the byte offset after the last string. The string byte length is computed using the difference between the current offset and the subsequent offset. The data type of these offsets is determined by `stringOffsetType`. The buffer view `byteOffset` must be aligned to a multiple of the `stringOffsetType` size."
+        },
+        "extensions": {},
+        "extras": {}
     },
-    "arrayOffsetType": {
-      "description": "The type of values in `arrayOffsetBufferView`.",
-      "default": "UINT32",
-      "anyOf": [
-        {
-          "const": "UINT8"
-        },
-        {
-          "const": "UINT16"
-        },
-        {
-          "const": "UINT32"
-        },
-        {
-          "const": "UINT64"
-        },
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "arrayOffsetBufferView": {
-      "allOf": [
-        {
-          "$ref": "glTFid.schema.json"
-        }
-      ],
-      "description": "The index of the buffer view containing offsets for variable-length arrays. The number of offsets is equal to the property table `count` plus one. The offsets represent the start positions of each array, with the last offset representing the position after the last array. The array length is computed using the difference between the current offset and the subsequent offset. If `componentType` is `STRING` the offsets index into the string offsets array (stored in `stringOffsetBufferView`), otherwise they index into the property array (stored in `bufferView`). The data type of these offsets is determined by `arrayOffsetType`. The buffer view `byteOffset` must be aligned to a multiple of the `arrayOffsetType` size."
-    },
-    "stringOffsetType": {
-      "description": "The type of values in `stringOffsetBufferView`.",
-      "default": "UINT32",
-      "anyOf": [
-        {
-          "const": "UINT8"
-        },
-        {
-          "const": "UINT16"
-        },
-        {
-          "const": "UINT32"
-        },
-        {
-          "const": "UINT64"
-        },
-        {
-          "type": "string"
-        }
-      ]
-    },
-    "stringOffsetBufferView": {
-      "allOf": [
-        {
-          "$ref": "glTFid.schema.json"
-        }
-      ],
-      "description": "The index of the buffer view containing offsets for strings. The number of offsets is equal to the number of string components plus one. The offsets represent the byte offsets of each string in the main `bufferView`, with the last offset representing the byte offset after the last string. The string byte length is computed using the difference between the current offset and the subsequent offset. The data type of these offsets is determined by `stringOffsetType`. The buffer view `byteOffset` must be aligned to a multiple of the `stringOffsetType` size."
-    },
-    "extensions": {},
-    "extras": {}
-  },
-  "required": [
-    "bufferView"
-  ]
+    "required": [
+        "bufferView"
+    ]
 }

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/propertyTable.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/propertyTable.schema.json
@@ -1,43 +1,43 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "propertyTable.schema.json",
-  "title": "Property Table",
-  "type": "object",
-  "description": "Features conforming to a class, organized as property values stored in columnar arrays.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
-    }
-  ],
-  "properties": {
-    "name": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The name of the property table, e.g. for display purposes."
-    },
-    "class": {
-      "type": "string",
-      "description": "The class that property values conform to. The value must be a class ID declared in the `classes` dictionary."
-    },
-    "count": {
-      "type": "integer",
-      "minimum": 1,
-      "description": "The number of features, as well as the number of elements in each property array."
-    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "propertyTable.schema.json",
+    "title": "Property Table",
+    "type": "object",
+    "description": "Features conforming to a class, organized as property values stored in columnar arrays.",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
     "properties": {
-      "type": "object",
-      "description": "A dictionary, where each key corresponds to a property ID in the class' `properties` dictionary and each value is an object describing where property values are stored. Required properties must be included in this dictionary.",
-      "minProperties": 1,
-      "additionalProperties": {
-        "$ref": "propertyTable.property.schema.json"
-      }
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the property table, e.g. for display purposes."
+        },
+        "class": {
+            "type": "string",
+            "description": "The class that property values conform to. The value must be a class ID declared in the `classes` dictionary."
+        },
+        "count": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "The number of features, as well as the number of elements in each property array."
+        },
+        "properties": {
+            "type": "object",
+            "description": "A dictionary, where each key corresponds to a property ID in the class' `properties` dictionary and each value is an object describing where property values are stored. Required properties must be included in this dictionary.",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "propertyTable.property.schema.json"
+            }
+        },
+        "extensions": {},
+        "extras": {}
     },
-    "extensions": {},
-    "extras": {}
-  },
-  "required": [
-    "class",
-    "count",
-    "properties"
-  ]
+    "required": [
+        "class",
+        "count",
+        "properties"
+    ]
 }

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/propertyTexture.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/propertyTexture.schema.json
@@ -1,44 +1,44 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "propertyTexture.schema.json",
-  "title": "Property Texture",
-  "type": "object",
-  "description": "Features conforming to a class, organized as property values stored in texture channels.",
-  "allOf": [
-    {
-      "$ref": "textureInfo.schema.json"
-    }
-  ],
-  "properties": {
-    "index": {},
-    "texCoord": {},
-    "name": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The name of the property texture, e.g. for display purposes."
-    },
-    "class": {
-      "type": "string",
-      "description": "The class this property texture conforms to. The value must be a class ID declared in the `classes` dictionary."
-    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "propertyTexture.schema.json",
+    "title": "Property Texture",
+    "type": "object",
+    "description": "Features conforming to a class, organized as property values stored in texture channels.",
+    "allOf": [
+        {
+            "$ref": "textureInfo.schema.json"
+        }
+    ],
     "properties": {
-      "type": "object",
-      "description": "A dictionary, where each key corresponds to a property ID in the class' `properties` dictionary and each value describes the texture channels containing property values.",
-      "minProperties": 1,
-      "additionalProperties": {
-        "type": "array",
-        "items": {
-          "type": "integer",
-          "minimum": 0
+        "index": {},
+        "texCoord": {},
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the property texture, e.g. for display purposes."
         },
-        "description": "Texture channels containing property values, identified by index."
-      }
+        "class": {
+            "type": "string",
+            "description": "The class this property texture conforms to. The value must be a class ID declared in the `classes` dictionary."
+        },
+        "properties": {
+            "type": "object",
+            "description": "A dictionary, where each key corresponds to a property ID in the class' `properties` dictionary and each value describes the texture channels containing property values.",
+            "minProperties": 1,
+            "additionalProperties": {
+                "type": "array",
+                "items": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "description": "Texture channels containing property values, identified by index."
+            }
+        },
+        "extensions": {},
+        "extras": {}
     },
-    "extensions": {},
-    "extras": {}
-  },
-  "required": [
-    "class",
-    "properties"
-  ]
+    "required": [
+        "class",
+        "properties"
+    ]
 }

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/schema.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/schema.schema.json
@@ -1,47 +1,47 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "schema.schema.json",
-  "title": "Schema",
-  "type": "object",
-  "description": "An object defining classes and enums.",
-  "allOf": [
-    {
-      "$ref": "glTFProperty.schema.json"
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "schema.schema.json",
+    "title": "Schema",
+    "type": "object",
+    "description": "An object defining classes and enums.",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the schema, e.g. for display purposes."
+        },
+        "description": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The description of the schema."
+        },
+        "version": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Application-specific version of the schema."
+        },
+        "classes": {
+            "type": "object",
+            "description": "A dictionary, where each key is a class ID and each value is an object defining the class. Class IDs may contain only alphanumeric and underscore characters.",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "class.schema.json"
+            }
+        },
+        "enums": {
+            "type": "object",
+            "description": "A dictionary, where each key is an enum ID and each value is an object defining the values for the enum. Enum IDs may contain only alphanumeric and underscore characters.",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "enum.schema.json"
+            }
+        },
+        "extensions": {},
+        "extras": {}
     }
-  ],
-  "properties": {
-    "name": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The name of the schema, e.g. for display purposes."
-    },
-    "description": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The description of the schema."
-    },
-    "version": {
-      "type": "string",
-      "minLength": 1,
-      "description": "Application-specific version of the schema."
-    },
-    "classes": {
-      "type": "object",
-      "description": "A dictionary, where each key is a class ID and each value is an object defining the class. Class IDs may contain only alphanumeric and underscore characters.",
-      "minProperties": 1,
-      "additionalProperties": {
-        "$ref": "class.schema.json"
-      }
-    },
-    "enums": {
-      "type": "object",
-      "description": "A dictionary, where each key is an enum ID and each value is an object defining the values for the enum. Enum IDs may contain only alphanumeric and underscore characters.",
-      "minProperties": 1,
-      "additionalProperties": {
-        "$ref": "enum.schema.json"
-      }
-    },
-    "extensions": {},
-    "extras": {}
-  }
 }


### PR DESCRIPTION
Use 4 spaces instead of 2 for indentation to be more similar to the glTF specs. The 3D Tiles specs also use 4 space indentation.