### PR TITLE
Replace property table buffer views with accessors.

### DIFF
--- a/extensions/2.0/Vendor/EXT_mesh_features/README.md
+++ b/extensions/2.0/Vendor/EXT_mesh_features/README.md
@@ -462,7 +462,7 @@ Property tables are defined as entries in the `propertyTables` array of the root
 
 The property table may provide value arrays for only a subset of the properties of its class, but class properties marked `required: true` must not be omitted. Each property value array given by the property table must be defined by a class property with the same alphanumeric property ID, with values matching the data type of the class property.
 
-> **Example:** A `tree_survey_2021-09-29` property table, implementing the `tree` class defined in earlier examples. The table contains observations for 10 trees, with each property defined by a buffer view containing 10 values.
+> **Example:** A `tree_survey_2021-09-29` property table, implementing the `tree` class defined in earlier examples. The table contains observations for 10 trees, with each property defined by an accessor containing 10 values.
 >
 > ```jsonc
 > {
@@ -475,14 +475,14 @@ The property table may provide value arrays for only a subset of the properties 
 >         "count": 10,
 >         "properties": {
 >           "species": {
->             "bufferView": 2,
->             "stringOffsetBufferView": 3
+>             "values": 2,
+>             "stringOffsets": 3
 >           },
 >           "birdCount": {
->             "bufferView": 1
+>             "values": 1
 >           },
 >           "height": {
->             "bufferView": 0
+>             "values": 0
 >           },
 >           // "diameter" is not required and has been omitted from this table.
 >         }
@@ -498,7 +498,7 @@ As in the core glTF specification, values of NaN, +Infinity, and -Infinity are n
 
 Each accessor `byteOffset` must be aligned to 4-byte boundaries, or to 8-byte boundaries for 64-bit property types.
 
-> **Implementation note:** Authoring tools may choose to align all buffer views to 8-byte boundaries for consistency, but client implementations should only depend on 8-byte alignment for buffer views containing 64-bit component types.
+> **Implementation note:** Authoring tools may choose to align all accessors to 8-byte boundaries for consistency, but client implementations should only depend on 8-byte alignment for accessors containing 64-bit component types.
 
 ### Property Textures
 
@@ -696,17 +696,17 @@ _This section is non-normative_
 
 The examples below shows the breadth of possible use cases for this extension.
 
-Example|Description|Image
---|--|--
-Triangle mesh|Feature IDs are assigned to each vertex to distinguish components of a building.|![Building Components](figures/building-components.png)
-Per-vertex properties<img width=700/>|An implicit feature ID is assigned to each vertex. The property table stores `FLOAT64` accuracy values. |![Per-vertex properties](figures/per-vertex-metadata.png)
-Per-triangle properties|An implicit feature ID is assigned to each set of three vertices. The property table stores `FLOAT64` area values.|![Per-triangle properties](figures/per-triangle-metadata.png)
-Per-point properties|An implicit feature ID is assigned to each point. The property table stores `FLOAT64` , `STRING`, and `ENUM` properties, which are not possible through glTF vertex attribute accessors alone.|![Point features](figures/point-features.png)
-Per-node properties|Vertices in node 0 and node 1, not batched together, are assigned different `offset` feature IDs.|![Per-node properties](figures/per-node-metadata.png)
-Multi-point features|A point cloud with two property tables, one storing properties for groups of points and the other storing properties for individual points.|![Multi-point features](figures/point-cloud-layers.png)
-Multi-instance features|Instanced tree meshes, where trees are assigned to groups with a per-GPU-instance feature ID attribute. One property table stores per-group properties and the other stores per-tree properties.|![Multi-instance features](figures/multi-instance-metadata.png)
-Material classification|A textured mesh using a property texture to store both material enums and normalized `UINT8` insulation values.|![Material Classification](figures/material-classification.png)
-Composite|A glTF containing a 3D mesh (house), a point cloud (tree), and instanced meshes (fencing) with three property tables.|![Composite Example](figures/composite-example.png)
+| Example                               | Description                                                                                                                                                                                      | Image                                                           |
+|---------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
+| Triangle mesh                         | Feature IDs are assigned to each vertex to distinguish components of a building.                                                                                                                 | ![Building Components](figures/building-components.png)         |
+| Per-vertex properties<img width=700/> | An implicit feature ID is assigned to each vertex. The property table stores `FLOAT64` accuracy values.                                                                                          | ![Per-vertex properties](figures/per-vertex-metadata.png)       |
+| Per-triangle properties               | An implicit feature ID is assigned to each set of three vertices. The property table stores `FLOAT64` area values.                                                                               | ![Per-triangle properties](figures/per-triangle-metadata.png)   |
+| Per-point properties                  | An implicit feature ID is assigned to each point. The property table stores `FLOAT64` , `STRING`, and `ENUM` properties, which are not possible through glTF vertex attribute accessors alone.   | ![Point features](figures/point-features.png)                   |
+| Per-node properties                   | Vertices in node 0 and node 1, not batched together, are assigned different `offset` feature IDs.                                                                                                | ![Per-node properties](figures/per-node-metadata.png)           |
+| Multi-point features                  | A point cloud with two property tables, one storing properties for groups of points and the other storing properties for individual points.                                                      | ![Multi-point features](figures/point-cloud-layers.png)         |
+| Multi-instance features               | Instanced tree meshes, where trees are assigned to groups with a per-GPU-instance feature ID attribute. One property table stores per-group properties and the other stores per-tree properties. | ![Multi-instance features](figures/multi-instance-metadata.png) |
+| Material classification               | A textured mesh using a property texture to store both material enums and normalized `UINT8` insulation values.                                                                                  | ![Material Classification](figures/material-classification.png) |
+| Composite                             | A glTF containing a 3D mesh (house), a point cloud (tree), and instanced meshes (fencing) with three property tables.                                                                            | ![Composite Example](figures/composite-example.png)             |
 
 ## Revision History
 

--- a/extensions/2.0/Vendor/EXT_mesh_features/README.md
+++ b/extensions/2.0/Vendor/EXT_mesh_features/README.md
@@ -644,31 +644,31 @@ The table below describes the mappings from properties to accessors exhaustively
 | ...                      | ...                      | ...             | ...                    |
 | `"UINT32"`               | `5125` <sup>2</sup>      | `"SINGLE"`      | `"SCALAR"`             |
 | ...                      | ...                      | ...             | ...                    |
-| `"UINT64"`               | `5121` <sup>3</sup>      | `"SINGLE"`      | `"SCALAR"`             |
+| `"UINT64"`               | `5135`                   | `"SINGLE"`      | `"SCALAR"`             |
 | ...                      | ...                      | ...             | ...                    |
 | `"INT8"`                 | `5120` (BYTE)            | `"SINGLE"`      | `"SCALAR"`             |
 | ...                      | ...                      | ...             | ...                    |
 | `"INT16"`                | `5122` (SHORT)           | `"SINGLE"`      | `"SCALAR"`             |
 | ...                      | ...                      | ...             | ...                    |
-| `"INT32"`                | `5124` (INT)<sup>4</sup> | `"SINGLE"`      | `"SCALAR"`             |
+| `"INT32"`                | `5124` (INT)<sup>3</sup> | `"SINGLE"`      | `"SCALAR"`             |
 | ...                      | ...                      | ...             | ...                    |
-| `"INT64"`                | `5121` <sup>3</sup>      | `"SINGLE"`      | `"SCALAR"`             |
+| `"INT64"`                | `5134`                   | `"SINGLE"`      | `"SCALAR"`             |
 | ...                      | ...                      | ...             | ...                    |
 | `"FLOAT32"`              | `5126` (FLOAT)           | `"SINGLE"`      | `"SCALAR"`             |
 | ...                      | ...                      | ...             | ...                    |
-| `"FLOAT64"`              | `5121` <sup>3</sup>      | `"SINGLE"`      | `"SCALAR"`             |
+| `"FLOAT64"`              | `5121` <sup>4</sup>      | `"SINGLE"`      | `"SCALAR"`             |
 | ...                      | ...                      | ...             | ...                    |
-| `"BOOLEAN"`              | `5121` <sup>3</sup>      | `"SINGLE"`      | `"SCALAR"`             |
-| `"BOOLEAN"`              | `5121` <sup>3</sup>      | `"ARRAY"`       | `"SCALAR"`<sup>1</sup> |
-| `"STRING"`               | `5121` <sup>3</sup>      | `"SINGLE"`      | `"SCALAR"`             |
-| `"STRING"`               | `5121` <sup>3</sup>      | `"ARRAY"`       | `"SCALAR"`<sup>1</sup> |
-| `"ENUM"`                 | `5121` <sup>3</sup>      | `"SINGLE"`      | `"SCALAR"`             |
-| `"ENUM"`                 | `5121` <sup>3</sup>      | `"ARRAY"`       | `"SCALAR"`<sup>1</sup> |
+| `"BOOLEAN"`              | `5121` <sup>4</sup>      | `"SINGLE"`      | `"SCALAR"`             |
+| `"BOOLEAN"`              | `5121` <sup>4</sup>      | `"ARRAY"`       | `"SCALAR"`<sup>1</sup> |
+| `"STRING"`               | `5121` <sup>4</sup>      | `"SINGLE"`      | `"SCALAR"`             |
+| `"STRING"`               | `5121` <sup>4</sup>      | `"ARRAY"`       | `"SCALAR"`<sup>1</sup> |
+| `"ENUM"`                 | Use enum `valueType`     | `"SINGLE"`      | `"SCALAR"`             |
+| `"ENUM"`                 | Use enum `valueType`     | `"ARRAY"`       | `"SCALAR"`<sup>1</sup> |
 
 <small><sup>1</sup> Use "SCALAR" accessors for "ARRAY" property types, with `componentCount` for fixed-length arrays.</small><br>
-<small><sup>3</sup> `5125` (UNSIGNED_INT) is disallowed by the base glTF 2.0 specification except as `primitive.indices`. `EXT_mesh_features` overrides this restriction.</small><br>
-<small><sup>3</sup> `5121` (UNSIGNED_BYTE) is used as general-purpose binary storage.</small><br>
-<small><sup>4</sup> `5124` (INT) is disallowed by the base glTF 2.0 specification. `EXT_mesh_features` overrides this restriction.</small>
+<small><sup>2</sup> `5125` (UNSIGNED_INT) is disallowed by the base glTF 2.0 specification except as `primitive.indices`. `EXT_mesh_features` overrides this restriction.</small><br>
+<small><sup>3</sup> `5124` (INT) is disallowed by the base glTF 2.0 specification. `EXT_mesh_features` overrides this restriction.</small><br>
+<small><sup>4</sup> `5121` (UNSIGNED_BYTE) is used as general-purpose binary storage.</small><br>
 
 Each accessor `byteOffset` must be aligned to 4-byte boundaries, or to 8-byte boundaries for 64-bit property types.
 

--- a/extensions/2.0/Vendor/EXT_mesh_features/README.md
+++ b/extensions/2.0/Vendor/EXT_mesh_features/README.md
@@ -666,9 +666,9 @@ The table below describes the mappings from properties to accessors exhaustively
 | `"ENUM"`                 | `5121` <sup>3</sup>      | `"ARRAY"`       | `"SCALAR"`<sup>1</sup> |
 
 <small><sup>1</sup> Use "SCALAR" accessors for "ARRAY" property types, with `componentCount` for fixed-length arrays.</small><br>
-<small><sup>3</sup> `5125` (UNSIGNED_INT) disallowed by base glTF 2.0 specification except as `primitive.indices`. `EXT_mesh_features` overrides this restriction.</small><br>
-<small><sup>3</sup> `5121` (UNSIGNED_BYTE) used as general-purpose binary storage.</small><br>
-<small><sup>4</sup> `5124` (INT) disallowed by base glTF 2.0 specification. `EXT_mesh_features` overrides this restriction.</small>
+<small><sup>3</sup> `5125` (UNSIGNED_INT) is disallowed by the base glTF 2.0 specification except as `primitive.indices`. `EXT_mesh_features` overrides this restriction.</small><br>
+<small><sup>3</sup> `5121` (UNSIGNED_BYTE) is used as general-purpose binary storage.</small><br>
+<small><sup>4</sup> `5124` (INT) is disallowed by the base glTF 2.0 specification. `EXT_mesh_features` overrides this restriction.</small>
 
 Each accessor `byteOffset` must be aligned to 4-byte boundaries, or to 8-byte boundaries for 64-bit property types.
 

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/propertyTable.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/propertyTable.property.schema.json
@@ -10,16 +10,16 @@
         }
     ],
     "properties": {
-        "bufferView": {
+        "values": {
             "allOf": [
                 {
                     "$ref": "glTFid.schema.json"
                 }
             ],
-            "description": "The index of the buffer view containing property values. The data type of property values is determined by the property definition: When `componentType` is `BOOLEAN` values are packed into a bitstream. When `componentType` is `STRING` values are stored as byte sequences and decoded as UTF-8 strings. When `componentType` is a numeric type values are stored as the provided `componentType`. When `componentType` is `ENUM` values are stored as the enum's `valueType`. Each enum value in the buffer must match one of the allowed values in the enum definition. When `type` is `ARRAY` elements are packed tightly together and the data type is based on the `componentType` following the same rules as above. `arrayOffsetBufferView` is required for variable-size arrays and `stringOffsetBufferView` is required for strings (for variable-length arrays of strings, both are required). The buffer view `byteOffset` must be aligned to a multiple of the `componentType` size."
+            "description": "The index of the accessor containing property values. The data type of property values is determined by the property definition: When `componentType` is `BOOLEAN` values are packed into a bitstream. When `componentType` is `STRING` values are stored as byte sequences and decoded as UTF-8 strings. When `componentType` is a numeric type values are stored as the provided `componentType`. When `componentType` is `ENUM` values are stored as the enum's `valueType`. Each enum value in the accessor must match one of the allowed values in the enum definition. When `type` is `ARRAY` elements are packed tightly together and the data type is based on the `componentType` following the same rules as above. `arrayOffsets` is required for variable-size arrays and `stringOffsets` is required for strings (for variable-length arrays of strings, both are required). The accessor `byteOffset` must be aligned to a multiple of the `componentType` size."
         },
         "arrayOffsetType": {
-            "description": "The type of values in `arrayOffsetBufferView`.",
+            "description": "The type of values in `arrayOffsets`.",
             "default": "UINT32",
             "anyOf": [
                 {
@@ -39,16 +39,16 @@
                 }
             ]
         },
-        "arrayOffsetBufferView": {
+        "arrayOffsets": {
             "allOf": [
                 {
                     "$ref": "glTFid.schema.json"
                 }
             ],
-            "description": "The index of the buffer view containing offsets for variable-length arrays. The number of offsets is equal to the property table `count` plus one. The offsets represent the start positions of each array, with the last offset representing the position after the last array. The array length is computed using the difference between the current offset and the subsequent offset. If `componentType` is `STRING` the offsets index into the string offsets array (stored in `stringOffsetBufferView`), otherwise they index into the property array (stored in `bufferView`). The data type of these offsets is determined by `arrayOffsetType`. The buffer view `byteOffset` must be aligned to a multiple of the `arrayOffsetType` size."
+            "description": "The index of the accessor containing offsets for variable-length arrays. The number of offsets is equal to the property table `count` plus one. The offsets represent the start positions of each array, with the last offset representing the position after the last array. The array length is computed using the difference between the current offset and the subsequent offset. If `componentType` is `STRING` the offsets index into the string offsets array (stored in `stringOffsets`), otherwise they index into the property array (stored in `values`). The data type of these offsets is determined by `arrayOffsetType`. The accessor `byteOffset` must be aligned to a multiple of the `arrayOffsetType` size."
         },
         "stringOffsetType": {
-            "description": "The type of values in `stringOffsetBufferView`.",
+            "description": "The type of values in `stringOffsets`.",
             "default": "UINT32",
             "anyOf": [
                 {
@@ -68,18 +68,18 @@
                 }
             ]
         },
-        "stringOffsetBufferView": {
+        "stringOffsets": {
             "allOf": [
                 {
                     "$ref": "glTFid.schema.json"
                 }
             ],
-            "description": "The index of the buffer view containing offsets for strings. The number of offsets is equal to the number of string components plus one. The offsets represent the byte offsets of each string in the main `bufferView`, with the last offset representing the byte offset after the last string. The string byte length is computed using the difference between the current offset and the subsequent offset. The data type of these offsets is determined by `stringOffsetType`. The buffer view `byteOffset` must be aligned to a multiple of the `stringOffsetType` size."
+            "description": "The index of the accessor containing offsets for strings. The number of offsets is equal to the number of string components plus one. The offsets represent the byte offsets of each string in the main `values`, with the last offset representing the byte offset after the last string. The string byte length is computed using the difference between the current offset and the subsequent offset. The data type of these offsets is determined by `stringOffsetType`. The accessor `byteOffset` must be aligned to a multiple of the `stringOffsetType` size."
         },
         "extensions": {},
         "extras": {}
     },
     "required": [
-        "bufferView"
+        "values"
     ]
 }


### PR DESCRIPTION
For discussion, this draft PR updates `EXT_mesh_features` to use accessor storage in favor of buffer view storage. Based on an earlier [GitHub Gist](https://gist.github.com/donmccurdy/00623ff3b125069633631e31bc72aae0) and its discussion. The crux of the change is a table listing property data types and their mappings to accessor component types. There may be better ways to describe this, but it seemed helpful to be very explicit here.

Some of the restrictions and complications with interleaved accessors and array or boolean types are awkward. Perhaps certain types should just be prohibited from making use of interleaved accessors.

Changes:

* Replaced property table buffer views with accessors
    * Renamed `property.bufferView` to `property.values`
    * Renamed `property.arrayOffsetBufferView` to `property.arrayOffsets`
    * Renamed `property.stringOffsetBufferView` to `property.stringOffsets`

Preview:

- [README.md](https://github.com/donmccurdy/glTF/blob/ext-mesh-features-v2.0.1/extensions/2.0/Vendor/EXT_mesh_features/README.md)