### PR TITLE
Fixed inlined examples to use componentType

### DIFF
--- a/extensions/2.0/Vendor/EXT_mesh_features/README.md
+++ b/extensions/2.0/Vendor/EXT_mesh_features/README.md
@@ -400,7 +400,7 @@ Class properties are defined as entries in the `class.properties` dictionary, in
 >               },
 >               "birdCount": {
 >                 "description": "Number of birds perching on the tree",
->                 "type": "UINT8",
+>                 "componentType": "UINT8",
 >                 "required": true
 >               },
 >               "height": {
@@ -549,15 +549,15 @@ Enum values may be encoded in images, as integer values according to their enum 
 >             "properties": {
 >               "insideTemperature": {
 >                 "name": "Inside Temperature",
->                 "type": "UINT8"
+>                 "componentType": "UINT8"
 >               },
 >               "outsideTemperature": {
 >                 "name": "Outside Temperature",
->                 "type": "UINT8"
+>                 "componentType": "UINT8"
 >               },
 >               "insulation": {
 >                 "name": "Insulation Thickness",
->                 "type": "UINT8",
+>                 "componentType": "UINT8",
 >                 "normalized": true
 >               },
 >             }

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/schema.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/schema.schema.json
@@ -13,7 +13,7 @@
         "id": {
             "type": "string",
             "minLength": 1,
-            "description": "Unique identifer for the schema."
+            "description": "Unique identifier for the schema."
         },
         "name": {
             "type": "string",


### PR DESCRIPTION
The inlined examples still referred to `type`, where `componentType` should be used
