### PR TITLE
Change primitive to mesh.primitive in EXT_mesh_features and EXT_feature_metadata schemas

### DIFF
--- a/extensions/2.0/Vendor/EXT_feature_metadata/README.md
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/README.md
@@ -333,7 +333,7 @@ Feature textures are defined with the following steps:
 
 1. A class is defined in the root `EXT_feature_metadata` extension object. This is used to describe the metadata in the texture.
 2. A feature texture is defined in the root `EXT_feature_metadata.featureTextures` object. This must reference the class ID defined in step 1.
-3. A feature texture is associated with a primitive by listing the feature texture ID in the `primitive.EXT_feature_metadata.featureTextures` array.
+3. A feature texture is associated with a primitive by listing the feature texture ID in the `mesh.primitive.EXT_feature_metadata.featureTextures` array.
 <img src="figures/feature-texture.png"  alt="Feature Texture" width="500">
 
 _Class and feature texture_

--- a/extensions/2.0/Vendor/EXT_feature_metadata/schema/mesh.primitive.EXT_feature_metadata.schema.json
+++ b/extensions/2.0/Vendor/EXT_feature_metadata/schema/mesh.primitive.EXT_feature_metadata.schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "primitive.EXT_feature_metadata.schema.json",
-    "title": "EXT_feature_metadata glTF Primitive extension",
+    "$id": "mesh.primitive.EXT_feature_metadata.schema.json",
+    "title": "EXT_feature_metadata glTF Mesh Primitive extension",
     "type": "object",
     "description": "`EXT_feature_metadata extension` for a primitive in a glTF model, to associate it with the root `EXT_feature_metadata` object.",
     "allOf": [

--- a/extensions/2.0/Vendor/EXT_mesh_features/README.md
+++ b/extensions/2.0/Vendor/EXT_mesh_features/README.md
@@ -84,7 +84,7 @@ Features are identified within a 3D asset by **Feature IDs** (unique identifiers
 
 #### Vertex Attribute
 
-*Defined in [primitive.EXT_mesh_features.schema.json](./schema/primitive.EXT_mesh_features.schema.json) and [featureIdAttribute.schema.json](./schema/featureIdAttribute.schema.json).*
+*Defined in [mesh.primitive.EXT_mesh_features.schema.json](./schema/mesh.primitive.EXT_mesh_features.schema.json) and [featureIdAttribute.schema.json](./schema/featureIdAttribute.schema.json).*
 
 Per-vertex feature IDs may be defined explicitly in a vertex attribute accessor.
 
@@ -127,7 +127,7 @@ The attribute's accessor `type` must be `"SCALAR"` and `normalized` must be fals
 
 #### Implicit Vertex Attribute
 
-*Defined in [primitive.EXT_mesh_features.schema.json](./schema/primitive.EXT_mesh_features.schema.json) and [featureIdAttribute.schema.json](./schema/featureIdAttribute.schema.json).*
+*Defined in [mesh.primitive.EXT_mesh_features.schema.json](./schema/mesh.primitive.EXT_mesh_features.schema.json) and [featureIdAttribute.schema.json](./schema/featureIdAttribute.schema.json).*
 
 Per-vertex feature IDs may also be defined implicitly, as a function of vertex index within the primitive. Implicit feature IDs reduce storage costs in several common cases, such as when all vertices in a primitive share the same feature ID, or each sequential group of `N` vertices (e.g. each triangle face) share the same feature ID.
 
@@ -168,7 +168,7 @@ For example
 
 ### Feature ID by Texture Coordinates
 
-*Defined in [primitive.EXT_mesh_features.schema.json](./schema/primitive.EXT_mesh_features.schema.json) and [featureIdTexture.schema.json](./schema/featureIdTexture.schema.json).*
+*Defined in [mesh.primitive.EXT_mesh_features.schema.json](./schema/mesh.primitive.EXT_mesh_features.schema.json) and [featureIdTexture.schema.json](./schema/featureIdTexture.schema.json).*
 
 Feature ID textures classify the pixels of an image into different features. Some use cases include image segmentation or marking regions on a map. Often per-texel feature IDs provide finer granularity than per-vertex feature IDs, as in the example below.
 
@@ -640,7 +640,7 @@ This extension is optional, meaning it should be placed in the `extensionsUsed` 
 ## Schema
 
 * [glTF.EXT_mesh_features.schema.json](./schema/glTF.EXT_mesh_features.schema.json)
-* [primitive.EXT_mesh_features.schema.json](./schema/primitive.EXT_mesh_features.schema.json)
+* [mesh.primitive.EXT_mesh_features.schema.json](./schema/mesh.primitive.EXT_mesh_features.schema.json)
 * [node.EXT_mesh_features.schema.json](./schema/node.EXT_mesh_features.schema.json)
 
 ## Examples

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/mesh.primitive.EXT_mesh_features.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/mesh.primitive.EXT_mesh_features.schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "primitive.EXT_mesh_features.schema.json",
-    "title": "EXT_mesh_features glTF Primitive extension",
+    "$id": "mesh.primitive.EXT_mesh_features.schema.json",
+    "title": "EXT_mesh_features glTF Mesh Primitive extension",
     "type": "object",
     "description": "`EXT_mesh_features` extension for a primitive in a glTF model, to associate it with the root `EXT_mesh_features` object.",
     "allOf": [


### PR DESCRIPTION
Using the full name `mesh.primitive` makes it easier to automatically extend core glTF's `mesh.primitive.schema.json`