### PR TITLE
Property texture properties as objects

### DIFF
--- a/extensions/2.0/Vendor/EXT_mesh_features/README.md
+++ b/extensions/2.0/Vendor/EXT_mesh_features/README.md
@@ -37,6 +37,8 @@ Optionally, this extension may be used in conjunction with [`EXT_mesh_gpu_instan
   - [Feature ID by Texture Coordinates](#feature-id-by-texture-coordinates)
   - [Feature ID by GPU Instance](#feature-id-by-gpu-instance)
   - [Specifying Feature IDs](#specifying-feature-ids)
+    - [Referencing Property Tables with Feature IDs](#referencing-property-tables-with-feature-ids)
+    - [Referencing External Resources with Feature IDs](#referencing-external-resources-with-feature-ids)
 - [Feature Properties](#feature-properties)
   - [Overview](#overview-2)
   - [Schema Definitions](#schema-definitions)
@@ -559,21 +561,29 @@ Enum values may be encoded in images, as integer values according to their enum 
 >                 "name": "Insulation Thickness",
 >                 "componentType": "UINT8",
 >                 "normalized": true
->               },
+>               }
 >             }
 >           }
 >         }
 >       },
->       "propertyTextures": [{
->         "class": "wall",
->         "index": 0,
->         "texCoord": 0,
->         "properties": {
->           "insideTemperature": [0],
->           "outsideTemperature": [1],
->           "insulation": [2]
+>       "propertyTextures": [
+>         {
+>           "class": "wall",
+>           "index": 0,
+>           "texCoord": 0,
+>           "properties": {
+>             "insideTemperature": {
+>               "channels": [0]
+>             },
+>             "outsideTemperature": {
+>               "channels": [1]
+>             },
+>             "insulation": {
+>               "channels": [2]
+>             }
+>           }
 >         }
->       }]
+>       ]
 >     }
 >   }
 > }
@@ -611,15 +621,21 @@ The `properties` map specifies the texture channels providing data for available
 > ```jsonc
 > // Root EXT_mesh_features extension:
 > {
->   "propertyTextures": [{
->     "class": "wind",
->     "index": 0,
->     "texCoord": 0,
->     "properties": {
->       "speed": [0],
->       "direction": [1, 2]
+>   "propertyTextures": [
+>     {
+>       "class": "wind",
+>       "index": 0,
+>       "texCoord": 0,
+>       "properties": {
+>         "speed": {
+>           "channels": [0]
+>         },
+>         "direction": {
+>           "channels": [1, 2]
+>         }
+>       }
 >     }
->   }]
+>   ]
 > }
 
 Texture filtering must be `9728` (NEAREST), `9729` (LINEAR), or undefined, for any texture object referenced as a property texture.
@@ -714,3 +730,5 @@ Composite|A glTF containing a 3D mesh (house), a point cloud (tree), and instanc
   * Each property texture now contains only a single texture
   * Property textures are now assumed to be in linear space, and must use nearest or linear filtering
   * Added a `schema.id` property
+* **Version 3.0.0** February 2022
+  * Elements in the property texture `properties` dictionary are now objects containing a `channels` property rather than an array of channels directly.

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/propertyTexture.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/propertyTexture.property.schema.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "propertyTexture.schema.json",
+    "title": "Property Texture Property in EXT_mesh_features",
+    "type": "object",
+    "description": "Texture channels containing property values.",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "channels": {
+            "type": "array",
+            "items": {
+                "type": "integer",
+                "minimum": 0
+            },
+            "description": "Texture channels containing property values, identified by index."
+        },
+        "extensions": {},
+        "extras": {}
+    },
+    "required": [
+        "channels"
+    ]
+}

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/propertyTexture.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/propertyTexture.schema.json
@@ -3,7 +3,7 @@
     "$id": "propertyTexture.schema.json",
     "title": "Property Texture in EXT_mesh_features",
     "type": "object",
-    "description": "Features conforming to a class, organized as property values stored in texture channels.",
+    "description": "Properties conforming to a class, organized as property values stored in texture channels.",
     "allOf": [
         {
             "$ref": "textureInfo.schema.json"
@@ -23,15 +23,10 @@
         },
         "properties": {
             "type": "object",
-            "description": "A dictionary, where each key corresponds to a property ID in the class' `properties` dictionary and each value describes the texture channels containing property values.",
+            "description": "A dictionary, where each key corresponds to a property ID in the class' `properties` dictionary and each value is an object describing where property values are stored. Required properties must be included in this dictionary.",
             "minProperties": 1,
             "additionalProperties": {
-                "type": "array",
-                "items": {
-                    "type": "integer",
-                    "minimum": 0
-                },
-                "description": "Texture channels containing property values, identified by index."
+                "$ref": "propertyTexture.property.schema.json"
             }
         },
         "extensions": {},


### PR DESCRIPTION
Items in the property texture `properties` dictionary are now objects instead of arrays of channels.

The reason for this change is to be able to add other properties like scale and offset for quantization, or extras/extensions. It's also more symmetric with property tables.

Before

```
"outsideTemperature": [1]
// nowhere to put other properties
```

After

```
"outsideTemperature": {
  "channels": [1],
  "scale": 0.1,
  "offset": 10.0
}
```

