### PR TITLE
Minor schema fixes for `EXT_mesh_features` revision

### DIFF
--- a/extensions/2.0/Vendor/EXT_structural_metadata/schema/class.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_structural_metadata/schema/class.property.schema.json
@@ -122,7 +122,7 @@
                     "$ref": "definitions.schema.json#/definitions/numericValue"
                 }
             ],
-            "description": "An offset to apply to property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types."
+            "description": "An offset to apply to property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types with numeric `componentType`."
         },
         "scale": {
             "allOf": [
@@ -130,7 +130,7 @@
                     "$ref": "definitions.schema.json#/definitions/numericValue"
                 }
             ],
-            "description": "A scale to apply to property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types."
+            "description": "A scale to apply to property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types with numeric `componentType`."
         },
         "max": {
             "allOf": [
@@ -138,7 +138,7 @@
                     "$ref": "definitions.schema.json#/definitions/numericValue"
                 }
             ],
-            "description": "Maximum allowed value for the property. Only applicable to `SCALAR`, `VECN`, and `MATN` types. The `normalized`, `offset`, and `scale` properties have no effect on the maximum, it always corresponds to the actual value."
+            "description": "Maximum allowed value for the property. Only applicable to `SCALAR`, `VECN`, and `MATN` types with numeric `componentType`. The `normalized`, `offset`, and `scale` properties have no effect on the maximum, it always corresponds to the actual value."
         },
         "min": {
             "allOf": [
@@ -146,7 +146,7 @@
                     "$ref": "definitions.schema.json#/definitions/numericValue"
                 }
             ],
-            "description": "Minimum allowed value for the property. Only applicable to `SCALAR`, `VECN`, and `MATN` types. The `normalized`, `offset`, and `scale` properties have no effect on the minimum, it always corresponds to the actual value."
+            "description": "Minimum allowed value for the property. Only applicable to `SCALAR`, `VECN`, and `MATN` types with numeric `componentType`. The `normalized`, `offset`, and `scale` properties have no effect on the minimum, it always corresponds to the actual value."
         },
         "required": {
             "type": "boolean",

--- a/extensions/2.0/Vendor/EXT_structural_metadata/schema/mesh.primitive.EXT_structural_metadata.schema.json
+++ b/extensions/2.0/Vendor/EXT_structural_metadata/schema/mesh.primitive.EXT_structural_metadata.schema.json
@@ -18,7 +18,7 @@
                 "$ref": "propertyTexture.schema.json"
             }
         },
-        "propertyMapping": {
+        "propertyMappings": {
             "type": "array",
             "description": "An array of indexes of property mappings in the root `EXT_structural_metadata` object.",
             "minItems": 1,


### PR DESCRIPTION
The `propertyMapping` property of a primitive is now an array, and thus, renamed to `propertyMappings`

The `description` in the property schema for `min/max/offset/scale` now mentions that these are only applicable when the `componentType` is numeric. 

(The analogous change for the latter in `3DTILES_metadata` is in https://github.com/CesiumGS/3d-tiles/pull/628 )
