### PR TITLE
Add EXT_instance_features extension

### DIFF
--- a/extensions/2.0/Vendor/EXT_instance_features/README.md
+++ b/extensions/2.0/Vendor/EXT_instance_features/README.md
@@ -1,0 +1,76 @@
+# EXT_instance_features
+
+## Contributors
+
+* Peter Gagliardi, Cesium
+* Sean Lilley, Cesium
+* Sam Suhag, Cesium
+* Don McCurdy, Independent
+* Marco Hutter, Cesium
+* Bao Tran, Cesium
+* Samuel Vargas, Cesium
+* Patrick Cozzi, Cesium
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the glTF 2.0 specification. It depends on the [`EXT_mesh_gpu_instancing`](../EXT_mesh_gpu_instancing) and [`EXT_mesh_features`](../EXT_mesh_features) extensions, to define Feature IDs for GPU instances.
+
+## Overview
+
+In most realtime 3D contexts, performance requirements demand minimizing the number of nodes and meshes in an asset. These requirements compete with interactivity, as applications may wish to merge static objects while still supporting interaction or inspection on those objects. A common performance optimizations is GPU instancing, using the `EXT_mesh_gpu_instancing` extension. But this destroys references to distinct objects, their attributes, and their behaviors.
+
+This extension defines a means of associating GPU instances that are created using the `EXT_mesh_gpu_instancing` extension with unique identifiers. These allow identifying the GPU instances as individual _features_, and are therefore referred to as _feature IDs_. The precise definition of the structure of these identifiers can be found in the `EXT_mesh_features` extension specification. 
+
+### Feature ID by GPU Instance
+
+*Defined in [node.EXT_instance_features.schema.json](./schema/node.EXT_instance_features.schema.json).*
+
+Feature IDs may be assigned to individual GPU instances using an instance attribute, or generated implicitly by instance index. Nodes with `EXT_instance_features` must also define an `EXT_mesh_gpu_instancing` extension, and are invalid without this dependency.
+
+> **Example:** A node defining instances of mesh `0`, with each instance having a feature ID in the `_FEATURE_ID_0` instance attribute.
+>
+> ```jsonc
+> {
+>   "nodes": [
+>     {
+>       "mesh": 0,
+>       "extensions": {
+>         "EXT_mesh_gpu_instancing": {
+>           "attributes": {
+>             "TRANSLATION": 0,
+>             "ROTATION": 1,
+>             "SCALE": 2,
+>             "_FEATURE_ID_0": 3
+>           },
+>         },
+>         "EXT_instance_features": {
+>           "featureIds": {
+>             "exampleFeatureId": {
+>               "featureCount": 10,
+>               "attribute": 0
+>             }
+>           }
+>         }
+>       }
+>     }
+>   ]
+> }
+> ```
+
+## Optional vs. Required
+
+This extension is optional, meaning it should be placed in the `extensionsUsed` list, but not in the `extensionsRequired` list.
+
+## Schema
+
+* [node.EXT_instance_features.schema.json](./schema/node.EXT_instance_features.schema.json)
+
+
+## Revision History
+
+This extension was originally part of a the `EXT_mesh_features` proposal extension. The revision history of this extension can be found in the [common revision history of the 3D Tiles Next extensions](https://github.com/CesiumGS/3d-tiles/blob/extension-revisions/next/REVISION_HISTORY.md).
+

--- a/extensions/2.0/Vendor/EXT_instance_features/README.md
+++ b/extensions/2.0/Vendor/EXT_instance_features/README.md
@@ -23,7 +23,7 @@ Written against the glTF 2.0 specification. It depends on the [`EXT_mesh_gpu_ins
 
 In most realtime 3D contexts, performance requirements demand minimizing the number of nodes and meshes in an asset. These requirements compete with interactivity, as applications may wish to merge static objects while still supporting interaction or inspection on those objects. A common performance optimizations is GPU instancing, using the `EXT_mesh_gpu_instancing` extension. But this does not allow to uniquely identify the instances that are created during rendering. 
 
-This extension defines a means of associating GPU instances that are created using the `EXT_mesh_gpu_instancing` extension with unique identifiers. These allow identifying the GPU instances as individual _features_, and are therefore referred to as _feature IDs_. 
+This extension defines a means of associating GPU instances that are created using the `EXT_mesh_gpu_instancing` extension with unique identifiers. These allow identifying the GPU instances as individual _features_, and are therefore referred to as _feature IDs_. These feature IDs are similar to the concept that is introduced in the [`EXT_mesh_features`](../EXT_mesh_features) extension. But instead of defining the feature IDs based on vertex attributes, the feature IDs are here defined using instance attributes. 
 
 ### Feature ID by GPU Instance
 

--- a/extensions/2.0/Vendor/EXT_instance_features/README.md
+++ b/extensions/2.0/Vendor/EXT_instance_features/README.md
@@ -17,7 +17,7 @@ Draft
 
 ## Dependencies
 
-Written against the glTF 2.0 specification. It depends on the [`EXT_mesh_gpu_instancing`](../EXT_mesh_gpu_instancing) and [`EXT_mesh_features`](../EXT_mesh_features) extensions, to define Feature IDs for GPU instances.
+Written against the glTF 2.0 specification. It depends on the [`EXT_mesh_gpu_instancing`](../EXT_mesh_gpu_instancing) extension. Each node that is extended with `EXT_instance_features` must also define an `EXT_mesh_gpu_instancing` extension object, and is invalid without this dependency.
 
 ## Overview
 
@@ -28,8 +28,6 @@ This extension defines a means of associating GPU instances that are created usi
 ### Feature ID by GPU Instance
 
 *Defined in [node.EXT_instance_features.schema.json](./schema/node.EXT_instance_features.schema.json).*
-
-Nodes with `EXT_instance_features` must also define an `EXT_mesh_gpu_instancing` extension, and are invalid without this dependency.
 
 Feature IDs may be assigned to individual GPU instances using an instance attribute, or generated implicitly by instance index.
 

--- a/extensions/2.0/Vendor/EXT_instance_features/README.md
+++ b/extensions/2.0/Vendor/EXT_instance_features/README.md
@@ -21,15 +21,19 @@ Written against the glTF 2.0 specification. It depends on the [`EXT_mesh_gpu_ins
 
 ## Overview
 
-In most realtime 3D contexts, performance requirements demand minimizing the number of nodes and meshes in an asset. These requirements compete with interactivity, as applications may wish to merge static objects while still supporting interaction or inspection on those objects. A common performance optimizations is GPU instancing, using the `EXT_mesh_gpu_instancing` extension. But this destroys references to distinct objects, their attributes, and their behaviors.
+In most realtime 3D contexts, performance requirements demand minimizing the number of nodes and meshes in an asset. These requirements compete with interactivity, as applications may wish to merge static objects while still supporting interaction or inspection on those objects. A common performance optimizations is GPU instancing, using the `EXT_mesh_gpu_instancing` extension. But this does not allow to uniquely identify the instances that are created during rendering. 
 
-This extension defines a means of associating GPU instances that are created using the `EXT_mesh_gpu_instancing` extension with unique identifiers. These allow identifying the GPU instances as individual _features_, and are therefore referred to as _feature IDs_. The precise definition of the structure of these identifiers can be found in the `EXT_mesh_features` extension specification. 
+This extension defines a means of associating GPU instances that are created using the `EXT_mesh_gpu_instancing` extension with unique identifiers. These allow identifying the GPU instances as individual _features_, and are therefore referred to as _feature IDs_. 
 
 ### Feature ID by GPU Instance
 
 *Defined in [node.EXT_instance_features.schema.json](./schema/node.EXT_instance_features.schema.json).*
 
-Feature IDs may be assigned to individual GPU instances using an instance attribute, or generated implicitly by instance index. Nodes with `EXT_instance_features` must also define an `EXT_mesh_gpu_instancing` extension, and are invalid without this dependency.
+Nodes with `EXT_instance_features` must also define an `EXT_mesh_gpu_instancing` extension, and are invalid without this dependency.
+
+Feature IDs may be assigned to individual GPU instances using an instance attribute, or generated implicitly by instance index.
+
+When the feature ID definition does not refer to an instance attribute, then the feature IDs that are assigned to the instances are equal to their index, in the range [0, count), where `count` is the `count` of the instance attribute accessors. When the feature ID definition refers to an instance attribute, then this attribute contains `count` feature ID values. Note that these values do not necessarily have to be distinct; this makes it possible to define _groups_ of instances that share the same identifier. 
 
 > **Example:** A node defining instances of mesh `0`, with each instance having a feature ID in the `_FEATURE_ID_0` instance attribute.
 >
@@ -68,7 +72,6 @@ This extension is optional, meaning it should be placed in the `extensionsUsed` 
 ## Schema
 
 * [node.EXT_instance_features.schema.json](./schema/node.EXT_instance_features.schema.json)
-
 
 ## Revision History
 

--- a/extensions/2.0/Vendor/EXT_instance_features/schema/featureId.schema.json
+++ b/extensions/2.0/Vendor/EXT_instance_features/schema/featureId.schema.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "featureId.schema.json",
+    "title": "Feature ID in EXT_instance_features",
+    "type": "object",
+    "description": "Feature IDs stored in a GPU mesh instanting attribute",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "featureCount": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "The number of unique features in the attribute."
+        },
+        "nullFeatureId": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "A value that indicates that no feature is associated with this instance."
+        },
+        "instanceAttribute": {
+            "description": "An attribute containing feature IDs. When this is omitted, then the feature IDs are assigned to the GPU instances by their index.",
+            "$ref": "featureIdInstanceAttribute.schema.json"
+        },
+        "propertyTable": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "The index of the property table containing per-feature property values. Only applicable when using the `EXT_structural_metadata` extension."
+        },
+        "extensions": {},
+        "extras": {}
+    },
+    "required": ["featureCount"]
+}

--- a/extensions/2.0/Vendor/EXT_instance_features/schema/featureId.schema.json
+++ b/extensions/2.0/Vendor/EXT_instance_features/schema/featureId.schema.json
@@ -20,9 +20,9 @@
             "minimum": 0,
             "description": "A value that indicates that no feature is associated with this instance."
         },
-        "instanceAttribute": {
+        "attribute": {
             "description": "An attribute containing feature IDs. When this is omitted, then the feature IDs are assigned to the GPU instances by their index.",
-            "$ref": "featureIdInstanceAttribute.schema.json"
+            "$ref": "featureIdAttribute.schema.json"
         },
         "propertyTable": {
             "type": "integer",

--- a/extensions/2.0/Vendor/EXT_instance_features/schema/featureIdAttribute..schema.json
+++ b/extensions/2.0/Vendor/EXT_instance_features/schema/featureIdAttribute..schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "featureIdInstanceAttribute.schema.json",
+    "$id": "featureIdAttribute.schema.json",
     "title": "Feature ID Attribute in EXT_instance_features",
     "type": "integer",
     "minimum": 0,

--- a/extensions/2.0/Vendor/EXT_instance_features/schema/featureIdInstanceAttibute..schema.json
+++ b/extensions/2.0/Vendor/EXT_instance_features/schema/featureIdInstanceAttibute..schema.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "featureIdInstanceAttribute.schema.json",
+    "title": "Feature ID Attribute in EXT_instance_features",
+    "type": "integer",
+    "minimum": 0,
+    "description": "An integer value used to construct a string in the format `_FEATURE_ID_<set index>` which is a reference to a key in `EXT_mesh_gpu_instancing.attributes` dictionary (e.g. a value of `0` corresponds to `_FEATURE_ID_0`)."
+}

--- a/extensions/2.0/Vendor/EXT_instance_features/schema/node.EXT_instance_features.schema.json
+++ b/extensions/2.0/Vendor/EXT_instance_features/schema/node.EXT_instance_features.schema.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "node.EXT_instance_features.schema.json",
+    "title": "EXT_instance_features glTF Node extension",
+    "type": "object",
+    "description": "An object describing per-instance feature IDs to be used as indices to property arrays in the property table.",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "featureIds": {
+            "type": "object",
+            "description": "A dictionary, where each key is the ID of the feature ID set, and each value is an object describing where feature IDs are stored. Set IDs may contain only alphanumeric and underscore characters.",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "featureId.schema.json"
+            }
+        },
+        "extensions": {},
+        "extras": {}
+    },
+    "required": [
+        "featureIds"
+    ]
+}


### PR DESCRIPTION
Derived from the [original EXT_mesh_features state](https://github.com/CesiumGS/glTF/tree/e8b8a1065ac9e3db571fa8af836fac5480020228/extensions/2.0/Vendor/EXT_mesh_features).

That typo in the commit message will haunt my forever. But here we go, the preview is at https://github.com/javagl/glTF/tree/ext-mesh-features-revision-instance-features/extensions/2.0/Vendor/EXT_instance_features 

The text originally said

> Feature IDs may be assigned to individual GPU instances using an instance attribute, or generated implicitly by instance index. 

It is not yet decided how this "implicit generation by index" should be accomplished. (Just omitting the `attribute` will not be compliant with the `featureId` schema)



