### PR TITLE
Update descriptions of offset/scale/min/max in schema

### DIFF
--- a/extensions/2.0/Vendor/EXT_structural_metadata/schema/class.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_structural_metadata/schema/class.property.schema.json
@@ -158,7 +158,7 @@
                     "$ref": "definitions.schema.json#/definitions/noDataValue"
                 }
             ],
-            "description": "A `noData` value represents missing data — also known as a sentinel value — wherever it appears. `BOOLEAN` properties may not specify `noData` values."
+            "description": "A `noData` value represents missing data — also known as a sentinel value — wherever it appears. `BOOLEAN` properties may not specify `noData` values. This is given as the plain property value, without the transforms from the `normalized`, `offset`, and `scale` properties."
         },
         "default": {
             "allOf": [
@@ -166,7 +166,7 @@
                     "$ref": "definitions.schema.json#/definitions/anyValue"
                 }
             ],
-            "description": "A default value to use when encountering a `noData` value or an omitted property."
+            "description": "A default value to use when encountering a `noData` value or an omitted property. The value is given in its final form, taking the effect of `normalized`, `offset`, and `scale` properties into account."
         },
         "semantic": {
             "type": "string",

--- a/extensions/2.0/Vendor/EXT_structural_metadata/schema/class.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_structural_metadata/schema/class.property.schema.json
@@ -121,7 +121,7 @@
                     "$ref": "definitions.schema.json#/definitions/numericValue"
                 }
             ],
-            "description": "An offset to apply to property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types."
+            "description": "An offset to apply to property values. Only applicable when the component type is `FLOAT32` or `FLOAT64`, or when the property is `normalized`."
         },
         "scale": {
             "allOf": [
@@ -129,7 +129,7 @@
                     "$ref": "definitions.schema.json#/definitions/numericValue"
                 }
             ],
-            "description": "A scale to apply to property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types."
+            "description": "A scale to apply to property values. Only applicable when the component type is `FLOAT32` or `FLOAT64`, or when the property is `normalized`."
         },
         "max": {
             "allOf": [
@@ -137,7 +137,7 @@
                     "$ref": "definitions.schema.json#/definitions/numericValue"
                 }
             ],
-            "description": "Maximum allowed value for the property. Only applicable to `SCALAR`, `VECN`, and `MATN` types. The `normalized`, `offset`, and `scale` properties have no effect on the maximum, it always corresponds to the actual value."
+            "description": "Maximum allowed value for the property. Only applicable to `SCALAR`, `VECN`, and `MATN` types. This is the maximum of all property values, after the transforms based on the `normalized`, `offset`, and `scale` properties have been applied."
         },
         "min": {
             "allOf": [
@@ -145,7 +145,7 @@
                     "$ref": "definitions.schema.json#/definitions/numericValue"
                 }
             ],
-            "description": "Minimum allowed value for the property. Only applicable to `SCALAR`, `VECN`, and `MATN` types. The `normalized`, `offset`, and `scale` properties have no effect on the minimum, it always corresponds to the actual value."
+            "description": "Minimum allowed value for the property. Only applicable to `SCALAR`, `VECN`, and `MATN` types. This is the minimum of all property values, after the transforms based on the `normalized`, `offset`, and `scale` properties have been applied."
         },
         "required": {
             "type": "boolean",

--- a/extensions/2.0/Vendor/EXT_structural_metadata/schema/propertyAttribute.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_structural_metadata/schema/propertyAttribute.property.schema.json
@@ -20,7 +20,7 @@
                     "$ref": "definitions.schema.json#/definitions/numericValue"
                 }
             ],
-            "description": "An offset to apply to property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types. Overrides the class property's `offset` if both are defined."
+            "description": "An offset to apply to property values. Only applicable when the component type is `FLOAT32` or `FLOAT64`, or when the property is `normalized`. Overrides the class property's `offset` if both are defined."
         },
         "scale": {
             "allOf": [
@@ -28,7 +28,23 @@
                     "$ref": "definitions.schema.json#/definitions/numericValue"
                 }
             ],
-            "description": "A scale to apply to property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types. Overrides the class property's `scale` if both are defined."
+            "description": "A scale to apply to property values. Only applicable when the component type is `FLOAT32` or `FLOAT64`, or when the property is `normalized`. Overrides the class property's `scale` if both are defined."
+        },
+        "max": {
+            "allOf": [
+                {
+                    "$ref": "definitions.schema.json#/definitions/numericValue"
+                }
+            ],
+            "description": "Maximum value present in the property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types. This is the maximum of all property values, after the transforms based on the `normalized`, `offset`, and `scale` properties have been applied."
+        },
+        "min": {
+            "allOf": [
+                {
+                    "$ref": "definitions.schema.json#/definitions/numericValue"
+                }
+            ],
+            "description": "Minimum value present in the property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types. This is the minimum of all property values, after the transforms based on the `normalized`, `offset`, and `scale` properties have been applied."
         },
         "extensions": {},
         "extras": {}

--- a/extensions/2.0/Vendor/EXT_structural_metadata/schema/propertyTable.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_structural_metadata/schema/propertyTable.property.schema.json
@@ -82,7 +82,7 @@
                     "$ref": "definitions.schema.json#/definitions/numericValue"
                 }
             ],
-            "description": "An offset to apply to property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types. Overrides the class property's `offset` if both are defined."
+            "description": "An offset to apply to property values. Only applicable when the component type is `FLOAT32` or `FLOAT64`, or when the property is `normalized`. Overrides the class property's `offset` if both are defined."
         },
         "scale": {
             "allOf": [
@@ -90,7 +90,7 @@
                     "$ref": "definitions.schema.json#/definitions/numericValue"
                 }
             ],
-            "description": "A scale to apply to property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types. Overrides the class property's `scale` if both are defined."
+            "description": "A scale to apply to property values. Only applicable when the component type is `FLOAT32` or `FLOAT64`, or when the property is `normalized`. Overrides the class property's `scale` if both are defined."
         },
         "max": {
             "allOf": [
@@ -98,7 +98,7 @@
                     "$ref": "definitions.schema.json#/definitions/numericValue"
                 }
             ],
-            "description": "Maximum value present in the property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types. The `normalized`, `offset`, and `scale` properties have no effect on the maximum, it always corresponds to the actual value."
+            "description": "Maximum value present in the property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types. This is the maximum of all property values, after the transforms based on the `normalized`, `offset`, and `scale` properties have been applied."
         },
         "min": {
             "allOf": [
@@ -106,7 +106,7 @@
                     "$ref": "definitions.schema.json#/definitions/numericValue"
                 }
             ],
-            "description": "Minimum value present in the property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types. The `normalized`, `offset`, and `scale` properties have no effect on the maximum, it always corresponds to the actual value."
+            "description": "Minimum value present in the property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types. This is the minimum of all property values, after the transforms based on the `normalized`, `offset`, and `scale` properties have been applied."
         },
         "extensions": {},
         "extras": {}

--- a/extensions/2.0/Vendor/EXT_structural_metadata/schema/propertyTexture.property.schema.json
+++ b/extensions/2.0/Vendor/EXT_structural_metadata/schema/propertyTexture.property.schema.json
@@ -27,7 +27,7 @@
                     "$ref": "definitions.schema.json#/definitions/numericValue"
                 }
             ],
-            "description": "An offset to apply to property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types. Overrides the class property's `offset` if both are defined."
+            "description": "An offset to apply to property values. Only applicable when the component type is `FLOAT32` or `FLOAT64`, or when the property is `normalized`. Overrides the class property's `offset` if both are defined."
         },
         "scale": {
             "allOf": [
@@ -35,7 +35,7 @@
                     "$ref": "definitions.schema.json#/definitions/numericValue"
                 }
             ],
-            "description": "A scale to apply to property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types. Overrides the class property's `scale` if both are defined."
+            "description": "A scale to apply to property values. Only applicable when the component type is `FLOAT32` or `FLOAT64`, or when the property is `normalized`. Overrides the class property's `scale` if both are defined."
         },
         "max": {
             "allOf": [
@@ -43,7 +43,7 @@
                     "$ref": "definitions.schema.json#/definitions/numericValue"
                 }
             ],
-            "description": "Maximum value present in the property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types. The `normalized`, `offset`, and `scale` properties have no effect on the maximum, it always corresponds to the actual value."
+            "description": "Maximum value present in the property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types. This is the maximum of all property values, after the transforms based on the `normalized`, `offset`, and `scale` properties have been applied."
         },
         "min": {
             "allOf": [
@@ -51,7 +51,7 @@
                     "$ref": "definitions.schema.json#/definitions/numericValue"
                 }
             ],
-            "description": "Minimum value present in the property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types. The `normalized`, `offset`, and `scale` properties have no effect on the maximum, it always corresponds to the actual value."
+            "description": "Minimum value present in the property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types. This is the minimum of all property values, after the transforms based on the `normalized`, `offset`, and `scale` properties have been applied."
         },
         "index": {},
         "texCoord": {},


### PR DESCRIPTION
Based on the changes in the 3D Metadata Specification from https://github.com/CesiumGS/3d-tiles/pull/640 , the descriptions in the schema have been updated.

