### PR TITLE
Change featureIds dictionary back to array

### DIFF
--- a/extensions/2.0/Vendor/EXT_instance_features/README.md
+++ b/extensions/2.0/Vendor/EXT_instance_features/README.md
@@ -50,12 +50,10 @@ When the feature ID definition does not refer to an instance attribute, then the
 >           },
 >         },
 >         "EXT_instance_features": {
->           "featureIds": {
->             "exampleFeatureId": {
->               "featureCount": 10,
->               "attribute": 0
->             }
->           }
+>           "featureIds": [{
+>             "featureCount": 10,
+>             "attribute": 0
+>           }]
 >         }
 >       }
 >     }

--- a/extensions/2.0/Vendor/EXT_instance_features/schema/featureId.schema.json
+++ b/extensions/2.0/Vendor/EXT_instance_features/schema/featureId.schema.json
@@ -3,7 +3,7 @@
     "$id": "featureId.schema.json",
     "title": "Feature ID in EXT_instance_features",
     "type": "object",
-    "description": "Feature IDs stored in a GPU mesh instanting attribute",
+    "description": "Feature IDs stored in a GPU mesh instancing attribute",
     "allOf": [
         {
             "$ref": "glTFProperty.schema.json"
@@ -19,6 +19,11 @@
             "type": "integer",
             "minimum": 0,
             "description": "A value that indicates that no feature is associated with this instance."
+        },
+        "label": {
+            "type": "string",
+            "pattern": "^[a-zA-Z]\\w*$",
+            "description": "A label assigned to this feature ID set. Labels may contain only alphanumeric and underscore characters."
         },
         "attribute": {
             "description": "An attribute containing feature IDs. When this is omitted, then the feature IDs are assigned to the GPU instances by their index.",

--- a/extensions/2.0/Vendor/EXT_instance_features/schema/featureId.schema.json
+++ b/extensions/2.0/Vendor/EXT_instance_features/schema/featureId.schema.json
@@ -22,8 +22,8 @@
         },
         "label": {
             "type": "string",
-            "pattern": "^[a-zA-Z]\\w*$",
-            "description": "A label assigned to this feature ID set. Labels may contain only alphanumeric and underscore characters."
+            "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+            "description": "A label assigned to this feature ID set. Labels must be alphanumeric identifiers matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`."
         },
         "attribute": {
             "description": "An attribute containing feature IDs. When this is omitted, then the feature IDs are assigned to the GPU instances by their index.",
@@ -37,5 +37,7 @@
         "extensions": {},
         "extras": {}
     },
-    "required": ["featureCount"]
+    "required": [
+        "featureCount"
+    ]
 }

--- a/extensions/2.0/Vendor/EXT_instance_features/schema/node.EXT_instance_features.schema.json
+++ b/extensions/2.0/Vendor/EXT_instance_features/schema/node.EXT_instance_features.schema.json
@@ -3,7 +3,7 @@
     "$id": "node.EXT_instance_features.schema.json",
     "title": "EXT_instance_features glTF Node extension",
     "type": "object",
-    "description": "An object describing per-instance feature IDs to be used as indices to property arrays in the property table.",
+    "description": "An object describing per-instance feature IDs.",
     "allOf": [
         {
             "$ref": "glTFProperty.schema.json"
@@ -11,8 +11,8 @@
     ],
     "properties": {
         "featureIds": {
-            "type": "object",
-            "description": "A dictionary, where each key is the ID of the feature ID set, and each value is an object describing where feature IDs are stored. Set IDs may contain only alphanumeric and underscore characters.",
+            "type": "array",
+            "description": "An array of feature ID sets.",
             "minProperties": 1,
             "additionalProperties": {
                 "$ref": "featureId.schema.json"

--- a/extensions/2.0/Vendor/EXT_mesh_features/README.md
+++ b/extensions/2.0/Vendor/EXT_mesh_features/README.md
@@ -44,7 +44,9 @@ A **feature** is a conceptual object in a virtual environment. Similar concepts 
 
 Features are identified within a 3D asset by **Feature IDs**. A mesh primitive may specify multiple sets of feature IDs. These feature ID sets might (for example) identify features at different levels of abstraction: there may be feature IDs that identify individual buildings, and feature IDs that identify different parts of each building.
 
-Each feature ID set is defined as a set of values that are associated with the conceptual parts of the model. The definition of the feature ID set may include a `nullFeatureId`, which is a value that indicates that a certain part is not considered to be an identifiable object. The definition also includes a `featureCount` value, which is the number of unique features that are identified. 
+Each feature ID set is defined as a set of values that are associated with the conceptual parts of the model. The definition of the feature ID set may include a `nullFeatureId`, which is a value that indicates that a certain part is not considered to be an identifiable object. The definition also includes a `featureCount` value, which is the number of unique features that are identified.
+
+The feature ID set may may also include a `label`, and alphanumeric string used to identify feature ID sets across different glTF primitives.
 
 Feature IDs can be associated with parts of a model in one of three ways:
 
@@ -88,12 +90,10 @@ Per-vertex feature IDs can be used to identify individual objects that have been
 >       "mode": 4,
 >       "extensions": {
 >         "EXT_mesh_features": {
->           "featureIds": { 
->             "exampleRectangles" : {
->               "featureCount": 2,
->               "attribute": 0
->             } 
->           }
+>           "featureIds": [{
+>             "featureCount": 2,
+>             "attribute": 0
+>           }]
 >         }
 >       }
 >     }
@@ -123,16 +123,14 @@ Feature ID textures classify the pixels of an image into different features. Som
 >       "material": 0,
 >       "extensions": {
 >         "EXT_mesh_features": {
->           "featureIds": {
->             "buildingComponents" : {
->               "featureCount": 4,     
->               "texture" : {
->                 "index": 0, 
->                 "texCoord": 0, 
->                 "channels": [0]
->               }
->             } 
->           }
+>           "featureIds": [{
+>             "featureCount": 4,    
+>             "texture" : {
+>               "index": 0, 
+>               "texCoord": 0, 
+>               "channels": [0]
+>             }
+>           }]
 >         }
 >       }
 >     }
@@ -169,8 +167,8 @@ When combined with the `EXT_structural_metadata` extension, feature ID sets can 
 > // Primitive:
 > "extensions": {
 >   "EXT_mesh_features": {
->     "featureIds": { 
->       "firstFeatureId" : {
+>     "featureIds": [
+>       {
 >         "featureCount": 4,     
 >         "texture" : {
 >           "index": 0, 
@@ -179,12 +177,12 @@ When combined with the `EXT_structural_metadata` extension, feature ID sets can 
 >         }, 
 >         "propertyTable": 1
 >       },
->       "secondFeatureId": {
+>       {
 >         "featureCount": 2,
 >         "attribute": 0,
 >         "propertyTable": 0
->       } 
->     }
+>       }
+>     ]
 >   }
 > }
 > ```

--- a/extensions/2.0/Vendor/EXT_mesh_features/README.md
+++ b/extensions/2.0/Vendor/EXT_mesh_features/README.md
@@ -46,7 +46,7 @@ Features are identified within a 3D asset by **Feature IDs**. A mesh primitive m
 
 Each feature ID set is defined as a set of values that are associated with the conceptual parts of the model. The definition of the feature ID set may include a `nullFeatureId`, which is a value that indicates that a certain part is not considered to be an identifiable object. The definition also includes a `featureCount` value, which is the number of unique features that are identified.
 
-The feature ID set may may also include a `label`, an alphanumeric string used to identify feature ID sets across different glTF primitives. Labels must match the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.
+The feature ID set may also include a `label`, an alphanumeric string used to identify feature ID sets across different glTF primitives. Labels must match the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.
 
 Feature IDs can be associated with parts of a model in one of three ways:
 

--- a/extensions/2.0/Vendor/EXT_mesh_features/README.md
+++ b/extensions/2.0/Vendor/EXT_mesh_features/README.md
@@ -46,7 +46,7 @@ Features are identified within a 3D asset by **Feature IDs**. A mesh primitive m
 
 Each feature ID set is defined as a set of values that are associated with the conceptual parts of the model. The definition of the feature ID set may include a `nullFeatureId`, which is a value that indicates that a certain part is not considered to be an identifiable object. The definition also includes a `featureCount` value, which is the number of unique features that are identified.
 
-The feature ID set may may also include a `label`, an alphanumeric string used to identify feature ID sets across different glTF primitives.
+The feature ID set may may also include a `label`, an alphanumeric string used to identify feature ID sets across different glTF primitives. Labels must match the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.
 
 Feature IDs can be associated with parts of a model in one of three ways:
 
@@ -92,7 +92,8 @@ Per-vertex feature IDs can be used to identify individual objects that have been
 >         "EXT_mesh_features": {
 >           "featureIds": [{
 >             "featureCount": 2,
->             "attribute": 0
+>             "attribute": 0,
+>             "label": "buildings"
 >           }]
 >         }
 >       }
@@ -107,7 +108,7 @@ Per-vertex feature IDs can be used to identify individual objects that have been
 
 Feature ID textures classify the pixels of an image into different features. Some use cases include image segmentation or marking regions on a map. Often per-texel feature IDs provide finer granularity than per-vertex feature IDs, as in the example below.
 
-> **Example:** A building facade, represented by a single quad. The primitive's `baseColorTexture` displays the visible appearance of the building, and its feature ID texture identifies regions of the quad (walls, door, roof, window) as distinct features. Both textures use the same texture coordinates, `TEXCOORD_0`, in this example.
+> **Example:** A building facade, represented by a single quad. The primitive's `baseColorTexture` displays the visible appearance of the building, and its feature ID texture identifies regions of the quad (door, roof, window) as distinct features. Texels assigned `nullFeatureId` do not belong to a feature. Both textures use the same texture coordinates, `TEXCOORD_0`, in this example.
 >
 > <img src="figures/feature-id-by-texture.png"  alt="Feature ID Texture" width="800">
 >
@@ -124,12 +125,13 @@ Feature ID textures classify the pixels of an image into different features. Som
 >       "extensions": {
 >         "EXT_mesh_features": {
 >           "featureIds": [{
->             "featureCount": 4,    
+>             "featureCount": 3,    
 >             "texture" : {
 >               "index": 0, 
 >               "texCoord": 0, 
 >               "channels": [0]
->             }
+>             },
+>             "nullFeatureId": 0,
 >           }]
 >         }
 >       }

--- a/extensions/2.0/Vendor/EXT_mesh_features/README.md
+++ b/extensions/2.0/Vendor/EXT_mesh_features/README.md
@@ -46,7 +46,7 @@ Features are identified within a 3D asset by **Feature IDs**. A mesh primitive m
 
 Each feature ID set is defined as a set of values that are associated with the conceptual parts of the model. The definition of the feature ID set may include a `nullFeatureId`, which is a value that indicates that a certain part is not considered to be an identifiable object. The definition also includes a `featureCount` value, which is the number of unique features that are identified.
 
-The feature ID set may may also include a `label`, and alphanumeric string used to identify feature ID sets across different glTF primitives.
+The feature ID set may may also include a `label`, an alphanumeric string used to identify feature ID sets across different glTF primitives.
 
 Feature IDs can be associated with parts of a model in one of three ways:
 

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/featureId.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/featureId.schema.json
@@ -20,6 +20,11 @@
             "minimum": 0,
             "description": "A value that indicates that no feature is associated with this vertex or texel."
         },
+        "label": {
+            "type": "string",
+            "pattern": "^[a-zA-Z]\\w*$",
+            "description": "A label assigned to this feature ID set. Labels may contain only alphanumeric and underscore characters."
+        },
         "attribute": {
             "description": "An attribute containing feature IDs. When `attribute` and `texture` are omitted the feature IDs are assigned to vertices by their index.",
             "$ref": "featureIdAttribute.schema.json"

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/featureId.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/featureId.schema.json
@@ -22,8 +22,8 @@
         },
         "label": {
             "type": "string",
-            "pattern": "^[a-zA-Z]\\w*$",
-            "description": "A label assigned to this feature ID set. Labels may contain only alphanumeric and underscore characters."
+            "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+            "description": "A label assigned to this feature ID set. Labels must be alphanumeric identifiers matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`."
         },
         "attribute": {
             "description": "An attribute containing feature IDs. When `attribute` and `texture` are omitted the feature IDs are assigned to vertices by their index.",

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/mesh.primitive.EXT_mesh_features.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/mesh.primitive.EXT_mesh_features.schema.json
@@ -3,7 +3,7 @@
     "$id": "mesh.primitive.EXT_mesh_features.schema.json",
     "title": "EXT_mesh_features glTF Mesh Primitive extension",
     "type": "object",
-    "description": "Feature ID sets of a mesh primitive.",
+    "description": "An object describing feature IDs for a mesh primitive.",
     "allOf": [
         {
             "$ref": "glTFProperty.schema.json"
@@ -11,8 +11,8 @@
     ],
     "properties": {
         "featureIds": {
-            "type": "object",
-            "description": "A dictionary, where each key is the ID of the feature ID set, and each value is an object describing where feature IDs are stored. Set IDs may contain only alphanumeric and underscore characters.",
+            "type": "array",
+            "description": "An array of feature ID sets.",
             "minProperties": 1,
             "additionalProperties": {
                 "$ref": "featureId.schema.json"

--- a/extensions/2.0/Vendor/EXT_structural_metadata/README.md
+++ b/extensions/2.0/Vendor/EXT_structural_metadata/README.md
@@ -93,7 +93,7 @@ A schema may be embedded in the extension directly or referenced externally with
 
 Template for metadata entities. Classes provide a list of property definitions. Instances of a class can be created from property values that conform to the class's property definitions. 
 
-Classes are defined as entries in the `schema.classes` dictionary, indexed by an alphanumeric class ID.
+Classes are defined as entries in the `schema.classes` dictionary, indexed by class ID. Class IDs must be alphanumeric identifiers matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.
 
 > **Example:** A "Tree" class, which might describe a table of tree measurements taken in a park. Property definitions are abbreviated here, and introduced in the next section.
 >
@@ -126,7 +126,7 @@ Classes are defined as entries in the `schema.classes` dictionary, indexed by an
 
 Class properties are defined abstractly in a class. The class is instantiated with specific values conforming to these properties. Class properties support a richer variety of data types than glTF accessors or GPU shading languages allow. Details about the supported types can be found in the [3D Metadata Specification](https://github.com/CesiumGS/3d-tiles/tree/main/specification/Metadata#property).
 
-Class properties are defined as entries in the `class.properties` dictionary, indexed by an alphanumeric property ID. 
+Class properties are defined as entries in the `class.properties` dictionary, indexed by property ID. Property IDs must be alphanumeric identifiers matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.
 
 > **Example:** A "Tree" class, which might describe a table of tree measurements taken in a park. Properties include species, height, and diameter of each tree, as well as the number of birds observed in its branches.
 >
@@ -177,7 +177,7 @@ Class properties are defined as entries in the `class.properties` dictionary, in
 
 Set of categorical types, defined as `(name, value)` pairs. Enum properties use an enum as their type.
 
-Enums are defined as entries in the `schema.enums` dictionary, indexed by an alphanumeric enum ID.
+Enums are defined as entries in the `schema.enums` dictionary, indexed by an enum ID. Enum IDs must be alphanumeric identifiers matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.
 
 > **Example:** A "Species" enum defining types of trees. An "Unspecified" enum value is optional, but when provided as the `noData` value for a property (see: [3D Metadata → No Data Values](https://github.com/CesiumGS/3d-tiles/tree/main/specification/Metadata#required-properties-and-no-data-values)) may be helpful to identify missing data.
 >

--- a/extensions/2.0/Vendor/EXT_structural_metadata/schema/class.schema.json
+++ b/extensions/2.0/Vendor/EXT_structural_metadata/schema/class.schema.json
@@ -22,7 +22,7 @@
         },
         "properties": {
             "type": "object",
-            "description": "A dictionary, where each key is a property ID and each value is an object defining the property. Property IDs may contain only alphanumeric and underscore characters.",
+            "description": "A dictionary, where each key is a property ID and each value is an object defining the property. Property IDs must be alphanumeric identifiers matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.",
             "minProperties": 1,
             "additionalProperties": {
                 "$ref": "class.property.schema.json"

--- a/extensions/2.0/Vendor/EXT_structural_metadata/schema/schema.schema.json
+++ b/extensions/2.0/Vendor/EXT_structural_metadata/schema/schema.schema.json
@@ -32,7 +32,7 @@
         },
         "classes": {
             "type": "object",
-            "description": "A dictionary, where each key is a class ID and each value is an object defining the class. Class IDs may contain only alphanumeric and underscore characters.",
+            "description": "A dictionary, where each key is a class ID and each value is an object defining the class. Class IDs must be alphanumeric identifiers matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.",
             "minProperties": 1,
             "additionalProperties": {
                 "$ref": "class.schema.json"
@@ -40,7 +40,7 @@
         },
         "enums": {
             "type": "object",
-            "description": "A dictionary, where each key is an enum ID and each value is an object defining the values for the enum. Enum IDs may contain only alphanumeric and underscore characters.",
+            "description": "A dictionary, where each key is an enum ID and each value is an object defining the values for the enum. Enum IDs must be alphanumeric identifiers matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.",
             "minProperties": 1,
             "additionalProperties": {
                 "$ref": "enum.schema.json"


### PR DESCRIPTION
One of the recent changes in `EXT_mesh_features` was to use a dictionary instead of an array for the `featureIds` property which enforces the usage of set IDs. There were some downsides to this:

* For basic usage a set ID may be not be needed, adding extra complexity and possibly confusion
* It was a breaking change for the older version of `EXT_mesh_features`
* Implementation churn

With `featureIds` as an array again, a new optional property is added called `label` which allows you to identify feature ID sets across different glTF primitives, or across different glTF assets such as in 3D Tiles.

Also added a regex to enforce proper naming of the label.