### PR TITLE
Fix example to correctly nest within "extensions"

### DIFF
--- a/extensions/2.0/Vendor/EXT_structural_metadata/README.md
+++ b/extensions/2.0/Vendor/EXT_structural_metadata/README.md
@@ -548,9 +548,11 @@ When property values are stored in a [Property Table](#property-tables), then th
 >     ...
 >     {
 >       "name": "A node with metadata",
->       "EXT_structural_metadata": {
->         "propertyTable": 1,
->         "index": 4
+>       "extensions": {
+>         "EXT_structural_metadata": {
+>           "propertyTable": 1,
+>           "index": 4
+>         }
 >       }
 >     }
 >   ]


### PR DESCRIPTION
There was a small mistake in the example of adding metadata to a node, since extensions must always be nested within "extensions" key, in any object.