### PR TITLE
Ext mesh features id clarifications

### DIFF
--- a/extensions/2.0/Vendor/EXT_mesh_features/README.md
+++ b/extensions/2.0/Vendor/EXT_mesh_features/README.md
@@ -43,6 +43,10 @@ Features are identified within a 3D asset by **Feature IDs**. A mesh primitive m
 
 Each feature ID set is defined as a set of values that are associated with the conceptual parts of the model. The definition of the feature ID set may include a `nullFeatureId`, which is a value that indicates that a certain part is not considered to be an identifiable object. The definition also includes a `featureCount` value, which is the number of unique features that are identified.
 
+> **Implementation note:** The `featureCount` is a _global_ number of unique features. The actual feature IDs that appear in one model will often only be a subset of a global set of possible IDs. So the `featureCount` will often be larger than the number of unique IDs that appear in one given model.
+>
+> The `nullFeatureId` does not contribute to the `featureCount`. When the `nullFeatureId` is defined, then there may be up to `featureCount+1` unique feature ID values in one model, if one of these values is the `nullFeatureId`.
+
 The feature ID set may also include a `label`, an alphanumeric string used to identify feature ID sets across different glTF primitives. Labels must match the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.
 
 Feature IDs can be associated with parts of a model in one of three ways:

--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/featureId.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/featureId.schema.json
@@ -34,8 +34,7 @@
             "$ref": "featureIdTexture.schema.json"
         },
         "propertyTable": {
-            "type": "integer",
-            "minimum": 0,
+            "allOf": [ { "$ref": "glTFid.schema.json" } ],
             "description": "The index of the property table containing per-feature property values. Only applicable when using the `EXT_structural_metadata` extension."
         },
         "extensions": {},


### PR DESCRIPTION
- The `propertyTable` of a feature ID should be a `glTFid`, and not a plain `integer` ( https://github.com/CesiumGS/3d-tiles/issues/751 )
- Add clarifications for https://github.com/CesiumGS/3d-tiles/issues/756

This might be fixing https://github.com/CesiumGS/3d-tiles/issues/756 . One aspect of that issue was whether the `featureCount` is actually required. But there likely _are_ cases where implementors might need this information (so it is unlikely that it will be removed from the specification). And regardless of whether it will be removed or not: As long as it is still _contained_ in the specification, the implementation note should help to clarify its _meaning_.

