### PR TITLE
Replace integer with glTFid

### DIFF
--- a/extensions/2.0/Vendor/EXT_structural_metadata/schema/EXT_structural_metadata.schema.json
+++ b/extensions/2.0/Vendor/EXT_structural_metadata/schema/EXT_structural_metadata.schema.json
@@ -11,8 +11,7 @@
     ],
     "properties": {
         "propertyTable": {
-            "type": "integer",
-            "minimum": 0,
+            "allOf": [ { "$ref": "glTFid.schema.json" } ],
             "description": "The index of the property table containing per-feature property values."
         },
         "index": {

--- a/extensions/2.0/Vendor/EXT_structural_metadata/schema/mesh.primitive.EXT_structural_metadata.schema.json
+++ b/extensions/2.0/Vendor/EXT_structural_metadata/schema/mesh.primitive.EXT_structural_metadata.schema.json
@@ -15,7 +15,7 @@
             "description": "An array of indexes of property textures in the root `EXT_structural_metadata` object.",
             "minItems": 1,
             "items": {
-                "type": "integer"
+                "allOf": [ { "$ref": "glTFid.schema.json" } ]
             }
         },
         "propertyAttributes": {
@@ -23,7 +23,7 @@
             "description": "An array of indexes of property attributes in the root `EXT_structural_metadata` object.",
             "minItems": 1,
             "items": {
-                "type": "integer"
+                "allOf": [ { "$ref": "glTFid.schema.json" } ]
             }
         },
         "extensions": {},


### PR DESCRIPTION
The references to property tables and property textures should use `glTFid` instead of `integer`.

Together with https://github.com/CesiumGS/glTF/pull/66 , this fixes https://github.com/CesiumGS/3d-tiles/issues/751

