### PR TITLE
Change integer to glTFid

### DIFF
--- a/extensions/2.0/Vendor/EXT_mesh_features/schema/featureId.schema.json
+++ b/extensions/2.0/Vendor/EXT_mesh_features/schema/featureId.schema.json
@@ -34,8 +34,7 @@
             "$ref": "featureIdTexture.schema.json"
         },
         "propertyTable": {
-            "type": "integer",
-            "minimum": 0,
+            "allOf": [ { "$ref": "glTFid.schema.json" } ],
             "description": "The index of the property table containing per-feature property values. Only applicable when using the `EXT_structural_metadata` extension."
         },
         "extensions": {},


### PR DESCRIPTION
The `propertyTable` of a feature ID should be a `glTFid`, and not a plain `integer` ( https://github.com/CesiumGS/3d-tiles/issues/751 )

