### PR TITLE
`EXT_structural_metadata` - `parent` class

### DIFF
--- a/extensions/2.0/Vendor/EXT_structural_metadata/README.md
+++ b/extensions/2.0/Vendor/EXT_structural_metadata/README.md
@@ -95,6 +95,8 @@ Template for metadata entities. Classes provide a list of property definitions. 
 
 Classes are defined as entries in the `schema.classes` dictionary, indexed by class ID. Class IDs must be alphanumeric identifiers matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.
 
+A class may specify a `parent` class, forming a class hierarchy. A class instance contains property values for its class as well as ancestor classes. Classes in a hierarchy cannot have the same property ID. Cyclical inheritance is disallowed.
+
 > **Example:** A "Tree" class, which might describe a table of tree measurements taken in a park. Property definitions are abbreviated here, and introduced in the next section.
 >
 > ```jsonc

--- a/extensions/2.0/Vendor/EXT_structural_metadata/schema/class.schema.json
+++ b/extensions/2.0/Vendor/EXT_structural_metadata/schema/class.schema.json
@@ -28,6 +28,11 @@
                 "$ref": "class.property.schema.json"
             }
         },
+        "parent": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The parent class ID. The class inherits all properties of its parent class and ancestor classes."
+        },
         "extensions": {},
         "extras": {}
     }


### PR DESCRIPTION
Adds the concept of a `parent` class that allows for class hierarchies, with some restrictions like no duplicate property IDs and no cyclical inheritance

@javagl would you mind taking a look?