### PR TITLE
`EXT_structural_metadata` - JSON encoding

### DIFF
--- a/extensions/2.0/Vendor/EXT_structural_metadata/README.md
+++ b/extensions/2.0/Vendor/EXT_structural_metadata/README.md
@@ -526,22 +526,21 @@ Property values are stored in a compact binary tabular format described in the [
 
 As a result, byte length of the `BIN` chunk may be up to 7 bytes larger than JSON-defined `buffer.byteLength` to satisfy alignment requirements.
 
-## Assigning Metadata
+## Assigning Metadata to glTF objects
 
 *Defined in [EXT_structural_metadata.schema.json](./schema/EXT_structural_metadata.schema.json).*
 
-When property values are stored in a [Property Table](#property-tables), then the entries of this table may be referenced from within the glTF asset: Each `node` of the glTF asset can contain an `EXT_structural_metadata` object that defines the source of the metadata values for this node. It contains the `propertyTable`, which is the index of the property table in the array of property tables of the root-level `EXT_structural_metadata` extension object, and the `index`, which is the index of the row in this table that contains the metadata values for the respective node.
+Each glTF object can contain an `EXT_structural_metadata` object that defines the metadata values for that object. It contains the name of the class that it is an instance of, as well as a dictionary of property values that correspond to the properties of that class. Each property value assigned shall be defined by a class property with the same property ID, with values matching the data type of the class property. The extension object may provide values for only a subset of the properties of its class, but class properties marked `required: true` shall not be omitted.
 
 > **Example:** 
 >
-> An example of metadata that is assigned to a node. It associates the given node with the metadata values that are stored in row 4 of the property table with index 1, referring to the array of property tables that are defined in the top-level `EXT_structural_metadata` extension object. 
+> An example of metadata that is assigned to a node.
 > 
 > ```jsonc
 > {
 >   "extensions": {
 >     "EXT_structural_metadata": {
 >       "schema": { ... },
->       "propertyTables": [ ... ]
 >     }
 >   },
 >   "nodes": [
@@ -550,8 +549,12 @@ When property values are stored in a [Property Table](#property-tables), then th
 >       "name": "A node with metadata",
 >       "extensions": {
 >         "EXT_structural_metadata": {
->           "propertyTable": 1,
->           "index": 4
+>           "class": "building",
+>           "properties": {
+>             "height": 16.8,
+>             "owners": [ "John Doe", "Jane Doe" ],
+>             "buildingType": "Residential"
+>           }
 >         }
 >       }
 >     }

--- a/extensions/2.0/Vendor/EXT_structural_metadata/schema/EXT_structural_metadata.schema.json
+++ b/extensions/2.0/Vendor/EXT_structural_metadata/schema/EXT_structural_metadata.schema.json
@@ -10,14 +10,17 @@
         }
     ],
     "properties": {
-        "propertyTable": {
-            "allOf": [ { "$ref": "glTFid.schema.json" } ],
-            "description": "The index of the property table containing per-feature property values."
+        "class": {
+            "type": "string",
+            "description": "The class that property values conform to. The value shall be a class ID declared in the `classes` dictionary of the metadata schema."
         },
-        "index": {
-            "type": "integer",
-            "minimum": 0,
-            "description": "The feature index (row index) used for looking up property values for this element."
+        "properties": {
+            "type": "object",
+            "description": "A dictionary, where each key corresponds to a property ID in the class' `properties` dictionary and each value contains the property values. The type of the value shall match the property definition: For `BOOLEAN` use `true` or `false`. For `STRING` use a JSON string. For numeric types use a JSON number. For `ENUM` use a valid enum `name`, not an integer value. For `ARRAY`, `VECN`, and `MATN` types use a JSON array containing values matching the `componentType`. Required properties shall be included in this dictionary.",
+            "minProperties": 1,
+            "additionalProperties": {
+                "$ref": "definitions.schema.json#/definitions/anyValue"
+            }
         },
         "extensions": {},
         "extras": {}

--- a/extensions/2.0/Vendor/EXT_structural_metadata/schema/glTF.EXT_structural_metadata.schema.json
+++ b/extensions/2.0/Vendor/EXT_structural_metadata/schema/glTF.EXT_structural_metadata.schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "glTF.EXT_structural_metadata.schema.json",
-    "title": "EXT_structural_metadata glTF extension",
+    "title": "EXT_structural_metadata glTF Document extension",
     "type": "object",
     "description": "glTF extension that provides structural metadata about vertices, texels, and features in a glTF asset.",
     "allOf": [


### PR DESCRIPTION
Metadata assigned to glTF objects - like nodes and materials - is now encoded in JSON rather than in binary in a property table. This is similar to tileset and tile metadata in 3D Tiles. This is a breaking change that shouldn't have a wide impact.