### PR TITLE
Add parent class to cesium-native branch

### DIFF
--- a/extensions/2.0/Vendor/EXT_structural_metadata/schema/class.schema.json
+++ b/extensions/2.0/Vendor/EXT_structural_metadata/schema/class.schema.json
@@ -28,6 +28,11 @@
                 "$ref": "class.property.schema.json"
             }
         },
+        "parent": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Experimental. The parent class ID."
+        },
         "extensions": {},
         "extras": {}
     }


### PR DESCRIPTION
https://github.com/CesiumGS/glTF/pull/70 proposes adding a `parent` property to a class. Even though this change isn't official yet we're already using it internally in the design tiler and would like to include it in cesium-native's generated code.