### PR TITLE
Clarify ground plane projection & fix up axis convention in constant LOD

### DIFF
--- a/extensions/2.0/Vendor/EXT_textureInfo_constant_lod/README.md
+++ b/extensions/2.0/Vendor/EXT_textureInfo_constant_lod/README.md
@@ -30,7 +30,7 @@ The `EXT_textureInfo_constant_lod` extension defines properties needed to calcul
 
 ![Constant LOD image](./figures/constantlod.jpg "Constant LOD image")
 
-Because this technique derives texture coordinates from the world-space X and Z position, it is designed for surfaces that are approximately parallel to the ground plane. On surfaces with other orientations, the projected texture coordinates may produce visual artifacts such as stretching.
+Because this technique derives texture coordinates from the world-space X and Z position, it is designed for surfaces that are approximately perpendicular to the Y-axis. On surfaces with other orientations, the projected texture coordinates may produce visual artifacts such as stretching.
 
 The extension specifies an alternative way of computing the texture coordinates, so if it is supported by the client then the `textureInfo`'s `texCoord` is not used. For maximum compatibility however, encoders still must provide `texCoord` UV coordinates so the texture renders even if the extension is not supported.
 

--- a/extensions/2.0/Vendor/EXT_textureInfo_constant_lod/README.md
+++ b/extensions/2.0/Vendor/EXT_textureInfo_constant_lod/README.md
@@ -92,7 +92,7 @@ frustrumWidth & \text{if } isOrthographicProjection \\
 
 Where $worldPosition$ is the vertex position in world coordinates, $eyeSpace$ is the vertex position in camera coordinates, and $frustumWidth$ is the frustum width in meters.
 
-The resulting $customUvCoords.xy$ contain the vertex's X and Z position in world coordinates. Because only the X and Z components of the world position are used, this technique assumes the textured surface is approximately horizontal (parallel to the ground plane). $customUvCoords.z$ is the negative eye-space depth (z-coordinate) from the camera to the fragment when using perspective projection. Since all points are equidistant to the camera when using orthographic projection, this value shall be set to the frustum width as a proxy for zoom level. $customUvCoords$ should then be passed into the fragment shader as a `varying`.
+The resulting $customUvCoords.xy$ contain the vertex's X and Z position in world coordinates. Because only the X and Z components of the world position are used, this technique assumes the textured surface is approximately perpendicular to the Y-axis. $customUvCoords.z$ is the negative eye-space depth (z-coordinate) from the camera to the fragment when using perspective projection. Since all points are equidistant to the camera when using orthographic projection, this value shall be set to the frustum width as a proxy for zoom level. $customUvCoords$ should then be passed into the fragment shader as a `varying`.
 
 In the fragment shader:
 

--- a/extensions/2.0/Vendor/EXT_textureInfo_constant_lod/README.md
+++ b/extensions/2.0/Vendor/EXT_textureInfo_constant_lod/README.md
@@ -30,6 +30,8 @@ The `EXT_textureInfo_constant_lod` extension defines properties needed to calcul
 
 ![Constant LOD image](./figures/constantlod.jpg "Constant LOD image")
 
+Because this technique derives texture coordinates from the world-space X and Z position, it is designed for surfaces that are approximately parallel to the ground plane. On surfaces with other orientations, the projected texture coordinates may produce visual artifacts such as stretching.
+
 The extension specifies an alternative way of computing the texture coordinates, so if it is supported by the client then the `textureInfo`'s `texCoord` is not used. For maximum compatibility however, encoders still must provide `texCoord` UV coordinates so the texture renders even if the extension is not supported.
 
 ## Specifying Constant LOD Texture Mapping
@@ -38,12 +40,12 @@ The `EXT_textureInfo_constant_lod` extension is defined on `textureInfo` structu
 
 Constant LOD uses the following properties:
 
-* `repetitions` - specifies the number of times the texture is repeated per meter in both the X and Y dimensions. Increasing this will make the texture pattern appear smaller; decreasing it will make it appear larger.
-* `offset` - used to shift the texture, specified as a pair of numbers in meters in the format [X, Y].
+* `repetitions` - specifies the number of times the texture is repeated per meter in both the X and Z dimensions. Increasing this will make the texture pattern appear smaller; decreasing it will make it appear larger.
+* `offset` - used to shift the texture, specified as a pair of numbers in meters in the format [X, Z].
 * `minClampDistance` - specifies the minimum distance in meters from the camera to the surface at which to clamp the texture. This value must not be greater than `maxClampDistance`.
 * `maxClampDistance` - specifies the maximum distance in meters from the camera to the surface at which to clamp the texture. This value must not be less than `minClampDistance`.
 
-For example, the following JSON defines a material with a texture at index 0 that is modified by the `EXT_textureInfo_constant_lod` extension. The extension has a `repetitions` value of 2 causing it to be repeated twice per meter, making its pattern appear half the size. It is shifted by 1 meter in the X direction and 0 meters in the Y direction. It also has a minimum clamp distance of 0.5 meters, meaning the constant LOD effect stops being present when the camera is 0.5m away from the surface or closer. This is a closer distance than the default value of 1m; therefore, this material requires a closer zoom before the texture stops adapting its level of detail (and for it to appear magnified). The absence of the `maxClampDistance` property means it has a default value of $2^{32}$, so the constant LOD effect will occur until the camera is $2^{32}$ away from the surface.
+For example, the following JSON defines a material with a texture at index 0 that is modified by the `EXT_textureInfo_constant_lod` extension. The extension has a `repetitions` value of 2 causing it to be repeated twice per meter, making its pattern appear half the size. It is shifted by 1 meter in the X direction and 0 meters in the Z direction. It also has a minimum clamp distance of 0.5 meters, meaning the constant LOD effect stops being present when the camera is 0.5m away from the surface or closer. This is a closer distance than the default value of 1m; therefore, this material requires a closer zoom before the texture stops adapting its level of detail (and for it to appear magnified). The absence of the `maxClampDistance` property means it has a default value of $2^{32}$, so the constant LOD effect will occur until the camera is $2^{32}$ away from the surface.
 
 ```json
 "materials": [
@@ -80,7 +82,7 @@ In the vertex shader:
 
 ```math
 \begin{aligned}
-customUvCoords.xy &= worldPosition.xy + offset\\
+customUvCoords.xy &= worldPosition.xz + offset\\
 customUvCoords.z &= \begin{cases}
 -eyeSpace & \text{if } isPerspectiveProjection \\
 frustrumWidth & \text{if } isOrthographicProjection \\
@@ -90,7 +92,7 @@ frustrumWidth & \text{if } isOrthographicProjection \\
 
 Where $worldPosition$ is the vertex position in world coordinates, $eyeSpace$ is the vertex position in camera coordinates, and $frustumWidth$ is the frustum width in meters.
 
-The resulting $customUvCoords.xy$ contain the vertex's X and Y position in world coordinates. $customUvCoords.z$ is the negative eye-space depth (z-coordinate) from the camera to the fragment when using perspective projection. Since all points are equidistant to the camera when using orthographic projection, this value shall be set to the frustum width as a proxy for zoom level. $customUvCoords$ should then be passed into the fragment shader as a `varying`.
+The resulting $customUvCoords.xy$ contain the vertex's X and Z position in world coordinates. Because only the X and Z components of the world position are used, this technique assumes the textured surface is approximately horizontal (parallel to the ground plane). $customUvCoords.z$ is the negative eye-space depth (z-coordinate) from the camera to the fragment when using perspective projection. Since all points are equidistant to the camera when using orthographic projection, this value shall be set to the frustum width as a proxy for zoom level. $customUvCoords$ should then be passed into the fragment shader as a `varying`.
 
 In the fragment shader:
 


### PR DESCRIPTION
Leaving this draft if we need some discussion first.

When trying to finish up the [CesiumJS implementation](https://github.com/CesiumGS/cesium/pull/13121) of `EXT_textureInfo_constant_lod`, I noticed some areas where the spec could be improved.

1. Clarify that constant LOD is designed for horizontal (ground-plane-parallel) surfaces
The spec formulas project texture coordinates onto a 2D plane using only two components of the world position. This means the technique is designed for surfaces approximately parallel to the ground plane, and non-horizontal surfaces may exhibit artifacts such as stretching. This was only implied by the formulas, but I added sentences in both the Overview and Formulas sections to make it explicit so implementers understand the intended use case better.

2. Change XY axes to XZ to match glTF's Y-up coordinate system
The original formulas used `worldPosition.xy`, which projects onto the XY plane. This is correct for Z-up coordinate systems like iTwin.js (which I referenced while writing the spec) and CesiumJS, but glTF uses a Y-up convention where the horizontal ground plane is XZ. I updated the formulas and all related references (offset, repetitions, prose descriptions) from XY to XZ.

@weegeekps @markschlosseratbentley let me know what you think