### PR TITLE
JSON schemas for external assets and unified file references

### DIFF
--- a/specification/2.1/Specification.adoc
+++ b/specification/2.1/Specification.adoc
@@ -1083,7 +1083,7 @@ On top of that, a sparse accessor includes a `sparse` JSON object describing the
 
 - `count`: number of displaced elements. This number **MUST NOT** be greater than the number of the base accessor elements.
 
-- `indices`: object describing the location and the component type of indices of values to be replaced. The indices **MUST** form a strictly increasing sequence. The indices **MUST NOT** be greater than or equal to the number of the base accessor elements. 
+- `indices`: object describing the location and the component type of indices of values to be replaced. The indices **MUST** form a strictly increasing sequence. The indices **MUST NOT** be greater than or equal to the number of the base accessor elements.
 
 - `values`: object describing the location of displaced elements corresponding to the indices referred from the `indices`.
 
@@ -2588,6 +2588,103 @@ See <<appendix-c-interpolation,Appendix C>> for additional information about int
 
 Skinned animation is achieved by animating the joints in the skin's joint hierarchy.
 
+[[file-references]]
+== Unified file references
+
+Files may be added to a top-level `files` array. The file's data may either be stored externally and referenced by a `uri`, stored internally in a base64-encoded data URI or IRI, or stored as binary in a buffer and referenced by `bufferView` index.
+
+Each file object **MUST** define a `mimeType` property, which may be any media type that matches the file's contents. If the file contains URIs, and the file is embedded data (base64 data URI or bufferView), those URIs are matched against other objects in the `files` array by `name`. Cyclical references between files are strictly prohibited.
+
+[source,json]
+----
+{
+    "files": [
+        {
+            "uri": "path-to-a.gltf",
+            "mimeType": "model/gltf+json"
+        }
+        {
+            "uri": "path-to-a.glb",
+            "mimeType": "model/gltf-binary"
+        },
+        {
+            "bufferView": 0
+            "mimeType": "model/gltf-binary"
+        }
+    ],
+}
+----
+
+[[external-references]]
+== Referencing external assets
+
+glTF 2.1 defines the ability to compose multiple glTF files together, by referencing external glTF files from another glTF file. Any glTF file which references another glTF file as an external asset is called a complex scene. Complex scenes are defined using multiple components: file references to define where the binary data is stored and external asset definitions that define the properties of the asset node.
+
+TODO: Diagram showing complex scene node hierarchy.
+
+External glTF assets may be added to a top-level `externalAssets` array. The external asset's data is provided by a file, with each object containing a `file` property that refers to an object in the `files` array by index. This means that an external asset's data may be stored internally as well as externally. Multiple objects in the `externalAssets` array may refer to the same `file`. All external assets **MUST** refer to files with the `"model/gltf-binary"` and `"model/gltf+json"` media types.
+
+TODO: Where to put note regarding gltf asset stored in bufferview needing to be a glb?
+
+[source,json]
+----
+{
+    "files": [
+        {
+            "uri": "path-to-a.gltf",
+            "mimeType": "model/gltf+json"
+        }
+        {
+            "uri": "path-to-a.glb",
+            "mimeType": "model/gltf-binary"
+        },
+        {
+            "bufferView": 0
+            "mimeType": "model/gltf-binary"
+        }
+    ],
+    "externalAssets": [
+        {
+            "file": 0
+        },
+        {
+            "file": 1
+        },
+        {
+            "file": 2
+        }
+    ],
+}
+----
+
+Nodes may contain an `externalAsset` property that refers to an external glTF asset in the `externalAssets` array by index.
+
+[source,json]
+----
+{
+    "nodes": [
+        {
+            "name": "RootNode",
+            "translation": [0, 0, 0],
+            "children": [1, 2]
+        },
+        {
+            "translation": [2, 0, 20],
+            "externalAsset": 0
+        },
+        {
+            "translation": [0, 0, 0],
+            "externalAsset": 1
+        },
+        {
+            "translation": [0, 1, 1],
+            "externalAsset": 2
+        }
+    ]
+}
+----
+
+This instantiates the external asset as this node in the scene hierarchy, such that the root of the file becomes this node. For vanilla glTF, this means that the scene object in the `scenes` array becomes this node, and the root nodes in the scene object of the nested glTF become children of this node. Extensions or future spec versions **MAY** alter this behavior. For glTF, only files with one scene and `"scene": 0` are valid targets.
 
 [[specifying-extensions]]
 == Specifying Extensions

--- a/specification/2.1/Specification.adoc
+++ b/specification/2.1/Specification.adoc
@@ -2591,9 +2591,13 @@ Skinned animation is achieved by animating the joints in the skin's joint hierar
 [[file-references]]
 == Unified file references
 
-Files **MAY** be added to a top-level `files` array. The file's data **MAY** be stored externally and referenced by a `uri`, stored internally in a base64-encoded data URI or IRI, or stored as binary in a buffer and referenced by `bufferView` index.
+Files **MAY** be added to a top-level `files` array. The file's data **MAY** be stored externally and referenced by a `uri` or stored as binary in a buffer and referenced by `bufferView` index.
 
-Each file object **MUST** define a `mimeType` property, which may be any media type that matches the file's contents. If the file contains URIs, and the file is embedded data (base64 data URI or bufferView), those URIs are matched against other objects in the `files` array by `name`. Cyclical references between files are strictly prohibited.
+Each file object **MUST** define a `mimeType` property, which may be any media type that matches the file's contents. If the file contains URIs, and the file is embedded data (base64 data URI or bufferView), those URIs are matched against other objects in the `files` array by `id`. Cyclical references between files are strictly prohibited.
+
+TODO: Mention logic for matching uris by name for embedded files. URI must match name exactly in child files, or implementation must call URI for asset.
+
+TODO: Deeper investigation on cyclical references and id's.
 
 [source,json]
 ----
@@ -2615,7 +2619,7 @@ Each file object **MUST** define a `mimeType` property, which may be any media t
 }
 ----
 
-[[external-references]]
+[[external-assets]]
 == Referencing external assets
 
 glTF 2.1 defines the ability to compose multiple glTF files together, by referencing external glTF files from another glTF file. Any glTF file which references another glTF file as an external asset is called a complex scene. Complex scenes are defined using multiple components: file references to define where the binary data is stored and external asset definitions that define the properties of the asset node.
@@ -2624,8 +2628,6 @@ TODO: Diagram showing complex scene node hierarchy.
 
 External glTF assets **MAY** be added to a top-level `externalAssets` array. The external asset **MUST** contain a `file` property that refers to an object in the `files` array by index. Multiple objects in the `externalAssets` array may refer to the same `file`. All external assets **MUST** refer to files with the `"model/gltf-binary"` and `"model/gltf+json"` media types.
 
-TODO: Where to put note regarding gltf asset stored in bufferview needing to be a glb?
-
 [source,json]
 ----
 {
@@ -2633,7 +2635,11 @@ TODO: Where to put note regarding gltf asset stored in bufferview needing to be 
         {
             "uri": "path-to-a.gltf",
             "mimeType": "model/gltf+json"
-        }
+        },
+        {
+            "uri": "path-to-a.bin",
+            "mimeType": "application/gltf-buffer"
+        },
         {
             "uri": "path-to-a.glb",
             "mimeType": "model/gltf-binary"
@@ -2648,16 +2654,20 @@ TODO: Where to put note regarding gltf asset stored in bufferview needing to be 
             "file": 0
         },
         {
-            "file": 1
+            "file": 2
         },
         {
-            "file": 2
+            "file": 3
         }
     ],
 }
 ----
 
 Nodes *MAY* contain an `externalAsset` property that refers to an external glTF asset in the `externalAssets` array by index. When a node has an `externalAsset` property, it **MUST NOT** have a `mesh` property.
+
+TODO: Add language to disallow other objects when an `externalAsset` is on a `node`. If a node has `externalAsset` and another object, then `externalAsset` has precedence; for handling 2.0 backwards compatibility.
+
+TODO: Add language to Node section as well.
 
 [source,json]
 ----

--- a/specification/2.1/Specification.adoc
+++ b/specification/2.1/Specification.adoc
@@ -2591,7 +2591,7 @@ Skinned animation is achieved by animating the joints in the skin's joint hierar
 [[file-references]]
 == Unified file references
 
-Files may be added to a top-level `files` array. The file's data may either be stored externally and referenced by a `uri`, stored internally in a base64-encoded data URI or IRI, or stored as binary in a buffer and referenced by `bufferView` index.
+Files **MAY** be added to a top-level `files` array. The file's data **MAY** be stored externally and referenced by a `uri`, stored internally in a base64-encoded data URI or IRI, or stored as binary in a buffer and referenced by `bufferView` index.
 
 Each file object **MUST** define a `mimeType` property, which may be any media type that matches the file's contents. If the file contains URIs, and the file is embedded data (base64 data URI or bufferView), those URIs are matched against other objects in the `files` array by `name`. Cyclical references between files are strictly prohibited.
 
@@ -2622,7 +2622,7 @@ glTF 2.1 defines the ability to compose multiple glTF files together, by referen
 
 TODO: Diagram showing complex scene node hierarchy.
 
-External glTF assets may be added to a top-level `externalAssets` array. The external asset's data is provided by a file, with each object containing a `file` property that refers to an object in the `files` array by index. This means that an external asset's data may be stored internally as well as externally. Multiple objects in the `externalAssets` array may refer to the same `file`. All external assets **MUST** refer to files with the `"model/gltf-binary"` and `"model/gltf+json"` media types.
+External glTF assets **MAY** be added to a top-level `externalAssets` array. The external asset **MUST** contain a `file` property that refers to an object in the `files` array by index. Multiple objects in the `externalAssets` array may refer to the same `file`. All external assets **MUST** refer to files with the `"model/gltf-binary"` and `"model/gltf+json"` media types.
 
 TODO: Where to put note regarding gltf asset stored in bufferview needing to be a glb?
 
@@ -2657,7 +2657,7 @@ TODO: Where to put note regarding gltf asset stored in bufferview needing to be 
 }
 ----
 
-Nodes may contain an `externalAsset` property that refers to an external glTF asset in the `externalAssets` array by index.
+Nodes *MAY* contain an `externalAsset` property that refers to an external glTF asset in the `externalAssets` array by index. When a node has an `externalAsset` property, it **MUST NOT** have a `mesh` property.
 
 [source,json]
 ----

--- a/specification/2.1/schema/externalAsset.schema.json
+++ b/specification/2.1/schema/externalAsset.schema.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "externalAsset.schema.json",
+    "title": "External Asset",
+    "type": "object",
+    "description": "An external asset referenced by a node.",
+    "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],
+    "properties": {
+        "file": {
+            "allOf": [ { "$ref": "glTFid.schema.json" } ],
+            "description": "The index of the file reference used for this external asset.",
+            "gltf_detailedDescription": "The index of the file reference used for this external asset."
+        },
+        "name": { },
+        "extensions": { },
+        "extras": { }
+    },
+    "required": [ "file" ]
+}

--- a/specification/2.1/schema/file.schema.json
+++ b/specification/2.1/schema/file.schema.json
@@ -1,0 +1,48 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "file.schema.json",
+    "title": "File Reference to External File",
+    "type": "object",
+    "description": "A file reference to an external file.",
+    "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],
+    "properties": {
+        "uri": {
+            "type": "string",
+            "description": "The URI (or IRI) of the external file.",
+            "format": "iri-reference",
+            "gltf_detailedDescription": "The URI (or IRI) of the external file.  Relative paths are relative to the current glTF asset.  Instead of referencing an external file, this field **MAY** contain a `data:`-URI. This field **MUST NOT** be defined when `bufferView` is defined.",
+            "gltf_uriType": "external-file"
+        },
+        "mimeType": {
+            "type": "string",
+            "description": "The MIME type of the external file.",
+            "gltf_detailedDescription": "The MIME type of the external file. This field **MUST** be defined when `bufferView` is defined.",
+            "anyOf": [
+                {
+                    "const": "model/gltf+json"
+                },
+                {
+                    "const": "model/gltf-binary"
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        },
+        "bufferView": {
+            "allOf": [ { "$ref": "glTFid.schema.json" } ],
+            "description": "The index of the bufferView that contains the external file.",
+            "gltf_detailedDescription": "The index of the bufferView that contains the external file. This field **MUST NOT** be defined when `uri` is defined."
+        },
+        "name": { },
+        "extensions": { },
+        "extras": { }
+    },
+    "dependencies": {
+        "bufferView": [ "mimeType" ]
+    },
+    "oneOf": [
+        { "required": [ "uri" ] },
+        { "required": [ "bufferView" ] }
+    ]
+}

--- a/specification/2.1/schema/file.schema.json
+++ b/specification/2.1/schema/file.schema.json
@@ -16,7 +16,7 @@
         "mimeType": {
             "type": "string",
             "description": "The MIME type of the external file.",
-            "gltf_detailedDescription": "The MIME type of the external file. This field **MUST** be defined when `bufferView` is defined.",
+            "gltf_detailedDescription": "The MIME type of the external file.",
             "anyOf": [
                 {
                     "const": "model/gltf+json"
@@ -38,9 +38,9 @@
         "extensions": { },
         "extras": { }
     },
-    "dependencies": {
-        "bufferView": [ "mimeType" ]
-    },
+    "required": [
+        "mimeType"
+    ],
     "oneOf": [
         { "required": [ "uri" ] },
         { "required": [ "bufferView" ] }

--- a/specification/2.1/schema/glTF.schema.json
+++ b/specification/2.1/schema/glTF.schema.json
@@ -72,6 +72,24 @@
             "minItems": 1,
             "gltf_detailedDescription": "An array of cameras.  A camera defines a projection matrix."
         },
+        "externalAssets": {
+            "type": "array",
+            "description": "An array of external assets.",
+            "items": {
+                "$ref": "externalAsset.schema.json"
+            },
+            "minItems": 1,
+            "gltf_detailedDescription": "An array of external assets.  An external asset is a node that references an external file."
+        },
+        "files": {
+            "type": "array",
+            "description": "An array of file references.",
+            "items": {
+                "$ref": "file.schema.json"
+            },
+            "minItems": 1,
+            "gltf_detailedDescription": "An array of file references.  A file reference is a pointer to an external file."
+        },
         "images": {
             "type": "array",
             "description": "An array of images.",

--- a/specification/2.1/schema/node.schema.json
+++ b/specification/2.1/schema/node.schema.json
@@ -37,7 +37,11 @@
         },
         "mesh": {
             "allOf": [ { "$ref": "glTFid.schema.json" } ],
-            "description": "The index of the mesh in this node."
+            "description": "The index of the mesh in this node. Cannot be used together with `externalAsset`."
+        },
+        "externalAsset": {
+            "allOf": [ { "$ref": "glTFid.schema.json" } ],
+            "description": "The index of the external asset in this node. Cannot be used together with `mesh`."
         },
         "rotation": {
             "type": "array",
@@ -91,7 +95,8 @@
         "anyOf": [
             { "required": [ "matrix", "translation" ] },
             { "required": [ "matrix", "rotation" ] },
-            { "required": [ "matrix", "scale" ] }
+            { "required": [ "matrix", "scale" ] },
+            { "required": [ "mesh", "externalAsset" ] }
         ]
     }
 }


### PR DESCRIPTION
This PR creates draft schemas based on the explainers for [External Assets](https://github.com/KhronosGroup/glTF/issues/2586) and [Unified File References](https://github.com/KhronosGroup/glTF/issues/2590). This is meant to be simple and doesn't include changes to the specification.

I also have some updated example files, but I don't currently have a good place to share those.

AI generated summary of changes:

* **Initialized glTF 2.1 Specification and Schemas:**
  * Copied the existing 2.0 specification and schema directories into a new `specification/2.1/` folder to begin draft work.

* **Created Unified File Reference Schema (`file.schema.json`):**
  * Defines references to external files, allowing them to be loaded either from an external `uri` or inline from a `bufferView`.
  * Standardizes `mimeType` as a required field for unified file references.

* **Created External Asset Schema (`externalAsset.schema.json`):**
  * Introduces an `externalAsset` definition that references an index in the `files` array.

* **Updated Root glTF Schema (`glTF.schema.json`):**
  * Added top-level `files` and `externalAssets` arrays to register external files and assets.

* **Updated Node Schema (`node.schema.json`):**
  * Added support for the `externalAsset` property.
  * Added validation constraints to ensure that `mesh` and `externalAsset` are mutually exclusive on a single node.