### PR TITLE
Add EXT_node_visibility_volume

### DIFF
--- a/extensions/2.1/Vendor/EXT_node_visibility_volume/README.md
+++ b/extensions/2.1/Vendor/EXT_node_visibility_volume/README.md
@@ -71,7 +71,9 @@ The following example is a glTF asset that uses the extension to define a visibi
           "visible": false,
           "extensions": {
             "EXT_node_visibility_volume": {
-              "shape": 0
+              "boundingVolume": {
+                "shape": 0
+              }
             }
           },
         },

--- a/extensions/2.1/Vendor/EXT_node_visibility_volume/README.md
+++ b/extensions/2.1/Vendor/EXT_node_visibility_volume/README.md
@@ -91,7 +91,7 @@ The `EXT_node_visibility_volume` object that is associated with `KHR_node_visibi
 
 _This section is non-normative._
 
-This extension's primary goal is to show a node and its hierarchy when the camera is within its bounding volume. Once the hierarchy is made visible, its contents may still be subject to other Level of Detail (LoD) methods. Implementations may add to this behavior (e.g., keeping the node visible when the camera is outside the volume), but should not add stricter conditions for visibility. For example, requiring the camera to be within a certain distance from the bounding volume's center is discouraged.
+This extension's primary goal is to show a node and its hierarchy when the camera is within its bounding volume. Once the hierarchy is made visible, its contents may still be subject to other Level of Detail (LoD) methods. Implementations may add to this behavior, but should not add stricter conditions for visibility. For example, requiring the camera to be within a certain distance from the bounding volume's center is discouraged.
 
 ## JSON Schema
 

--- a/extensions/2.1/Vendor/EXT_node_visibility_volume/README.md
+++ b/extensions/2.1/Vendor/EXT_node_visibility_volume/README.md
@@ -1,0 +1,96 @@
+<!--
+SPDX-FileCopyrightText: 2026 Bentley Systems, Incorporated
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# EXT_node_visibility_volume
+
+## Contributors
+
+- Adam Morris, Cesium
+- Jeshurun Hembd, Cesium
+- Marco Hutter, Cesium
+- Sean Lilley, Cesium
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the glTF 2.1 specification.
+
+Depends on [KHR_node_visibility](../../../2.0/Khronos/KHR_node_visibility).
+
+## Optional vs. Required
+
+This extension is optional.
+
+Implementations that do not support this extension (but only the `KHR_node_visibility` extension) will simply use the value of the `visible` flag that is defined in the `KHR_node_visibility` extension.
+
+## Overview
+
+This extension adds support for a visibility bounding volume for `EXT_node_visibility`. The visibility bounding volume allows a node's `visible` flag to be set to `true` when a viewer's camera origin point is within the bounding volume.
+
+## Extending the visibility extension
+
+The `KHR_node_visibility` extension is associated with a node, and defines the `visible` flag that indicates whether a node and all its descendants are visible. `EXT_node_visibility_volume` extends this extension by allowing a bounding volume to be associated to the visibility object. This bounding volume fits the same rules and criteria for node bounding volumes as defined in [§3.5.4. of the glTF 2.1 specification](/specification/2.1/Specification.adoc).
+
+The following example is a glTF asset that uses the extension to define a visibility bounding volume:
+
+```json
+{
+  "asset": {
+    "version": 2.1,
+  },
+  "files": [
+    {
+      "mimeType": "model/gltf-binary",
+      "uri": "example.glb",
+    },
+  ],
+  "externalAssets": [
+    {
+      "file": 0,
+    },
+  ],
+  "shapes": [
+    {
+      "type": "box",
+      "box": {
+        "size": [7.476, 7.44, 26.804]
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "externalAsset": 0,
+      "extensions": {
+        "KHR_node_visibility": {
+          "visible": false,
+          "extensions": {
+            "EXT_node_visibility_volume": {
+              "shape": 0
+            }
+          },
+        },
+      },
+    },
+  ],
+  "scene": 0,
+  "scenes": [{ "nodes": [0] }],
+}
+```
+
+The `EXT_node_visibility_volume` object that is associated with `KHR_node_visibility` object of the only node defines the bounding volume who's extents are used to determine if the node and it's hierarchy is visible.
+
+## Runtime Behavior
+
+_This section is non-normative._
+
+This extension's primary goal is to show a node and its hierarchy when the camera is within its bounding volume. Once the hierarchy is made visible, its contents may still be subject to other Level of Detail (LoD) methods. Implementations may add to this behavior (e.g., keeping the node visible when the camera is outside the volume), but should not add stricter conditions for visibility. For example, requiring the camera to be within a certain distance from the bounding volume's center is discouraged.
+
+## JSON Schema
+
+- [EXT_node_visibility_volume.schema.json](./schema/EXT_node_visibility_volume.schema.json)

--- a/extensions/2.1/Vendor/EXT_node_visibility_volume/REUSE.toml
+++ b/extensions/2.1/Vendor/EXT_node_visibility_volume/REUSE.toml
@@ -1,0 +1,6 @@
+version = 1
+
+[[annotations]]
+path = ["figures/**/*.jpg", "figures/**/*.png", "schema/**/*.schema.json"]
+SPDX-FileCopyrightText = "2026 Bentley Systems, Incorporated"
+SPDX-License-Identifier = "CC-BY-4.0"

--- a/extensions/2.1/Vendor/EXT_node_visibility_volume/schema/EXT_node_visibility_volume.schema.json
+++ b/extensions/2.1/Vendor/EXT_node_visibility_volume/schema/EXT_node_visibility_volume.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "EXT_node_visibility_volume.schema.json",
+  "title": "EXT_node_visibility_volume",
+  "description": "Defines the structure of the extension object that is associated with a KHR_node_visibility object to define a visibility bounding volume.",
+  "type": "object",
+  "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+  "properties": {
+      "boundingVolume": {
+          "$ref": "boundingVolume.schema.json",
+          "description": "The visibility bounding volume for the node.",
+          "glTF_detailedDescription": "The visibility bounding volume allows a node's `visible` flag to be set to `true` when a viewer's camera origin point is within the bounding volume."
+      }
+  },
+  "required": [
+      "boundingVolume"
+  ]
+}


### PR DESCRIPTION
This adds the `EXT_node_visibility_volume` extension we discussed yesterday afternoon. It is intended to be an alternative to #121 that relies more on glTF definitions and concepts include version 2.1's bounding volume hierarchies and the `KHR_node_visibility` extension.

The premise is more or less the same as outlined in #121 with some distinct differences:

- This extension relies on `KHR_node_visibility` to signal whether or not the node is visible.
- The existing rules on bounding volumes are used. These will be in §3.5.4. of the glTF 2.1 specification.
- To keep with the spirit of glTF, we do not dictate any implementation details or requirements, other than a non-normative recommendation for implementations to avoid adding stricter conditions for visibility.