### PR TITLE
Add subtree attributes for region and s2 shapes

### DIFF
--- a/extensions/2.1/Vendor/3DTILES_shape_ellipsoid_region/README.md
+++ b/extensions/2.1/Vendor/3DTILES_shape_ellipsoid_region/README.md
@@ -135,3 +135,18 @@ longitude| From west to east (increasing longitude)
 latitude| From south to north (increasing latitude)
 height| From bottom to top (increasing height)
 
+## Subtree Attributes
+
+This extension defines the following [subtree tile attribute semantics](../3DTILES_subtree/README.md#tile-attributes):
+
+Attribute Semantic|Accessor Type|Component Type|Description
+--|--|--|--
+`"TILE_BOUNDING_REGION"`|`"VEC4"`|`5130` (DOUBLE)|The bounding region of the tile, in the order `(minimum longitude, minimum latitude, maximum longitude, maximum latitude)`.
+`"TILE_MINIMUM_HEIGHT"`|`"SCALAR"`|`5130` (DOUBLE)|The minimum height of the tile above (or below) the ellipsoid.
+
+This extension defines the following [subtree content attribute semantics](../3DTILES_subtree/README.md#content-attributes):
+
+Attribute Semantic|Accessor Type|Component Type|Description
+--|--|--|--
+`"CONTENT_BOUNDING_REGION"`|`"VEC4"`|`5130` (DOUBLE)|The bounding region of the content, in the order `(minimum longitude, minimum latitude, maximum longitude, maximum latitude)`.
+`"CONTENT_MINIMUM_HEIGHT"`|`"SCALAR"`|`5130` (DOUBLE)|The minimum height of the content above (or below) the ellipsoid.

--- a/extensions/2.1/Vendor/3DTILES_shape_s2/README.md
+++ b/extensions/2.1/Vendor/3DTILES_shape_s2/README.md
@@ -39,6 +39,7 @@ This extension is required, meaning it **MUST** be placed in both `extensionsReq
 - [S2 Shape](#s2-shape)
 - [Implicit Subdivision](#implicit-subdivision)
   - [Availability](#availability)
+- [Subtree Attributes](#subtree-attributes)
 - [Schema](#schema)
 - [Implementation Examples](#implementation-examples)
 
@@ -560,6 +561,22 @@ The following example illustrates usage of `3DTILES_shape_s2` to represent all 6
   ]
 }
 ```
+
+## Subtree Attributes
+
+This extension defines the following [subtree tile attribute semantics](../3DTILES_subtree/README.md#tile-attributes):
+
+Attribute Semantic|Accessor Type|Component Type|Description
+--|--|--|--
+`"TILE_BOUNDING_S2_CELL"`|`"SCALAR"`|`5135` (UNSIGNED INT64)|The bounding volume of the tile, expressed as an [S2 Cell ID](#cell-ids) using the 64-bit representation instead of the hexadecimal representation.
+`"TILE_MINIMUM_HEIGHT"`|`"SCALAR"`|`5130` (DOUBLE)|The minimum height of the tile above (or below) the ellipsoid.
+
+This extension defines the following [subtree content attribute semantics](../3DTILES_subtree/README.md#content-attributes):
+
+Attribute Semantic|Accessor Type|Component Type|Description
+--|--|--|--
+`"CONTENT_BOUNDING_S2_CELL"`|`"SCALAR"`|`5135` (UNSIGNED INT64)|The bounding volume of the content, expressed as an [S2 Cell ID](#cell-ids) using the 64-bit representation instead of the hexadecimal representation.
+`"CONTENT_MINIMUM_HEIGHT"`|`"SCALAR"`|`5130` (DOUBLE)|The minimum height of the content above (or below) the ellipsoid.
 
 ## Schema
 


### PR DESCRIPTION
Addresses this aspect of the [changelog](https://github.com/CesiumGS/3d-tiles/blob/main/next/2.0/CHANGES.md):

<img width="1482" height="209" alt="image" src="https://github.com/user-attachments/assets/ee347235-5630-49b4-bfd2-4c854a8354d5" />

`TILE_MINIMUM_HEIGHT` and `CONTENT_MINIMUM_HEIGHT` are defined in both extensions, which I think is ok.