### PR TITLE
Add `EXT_geospatial_crs_source`

### DIFF
--- a/extensions/2.1/Vendor/EXT_geospatial_crs/README.md
+++ b/extensions/2.1/Vendor/EXT_geospatial_crs/README.md
@@ -85,6 +85,7 @@ The following example shows an asset defined in UTM Zone 11N coordinates using `
       }
     }
   }
+}
 ```
 
 ## Schema

--- a/extensions/2.1/Vendor/EXT_geospatial_crs_source/README.md
+++ b/extensions/2.1/Vendor/EXT_geospatial_crs_source/README.md
@@ -84,7 +84,14 @@ During traversal, the `EXT_geospatial_crs_source` transform may be used instead 
 
 | Property | Type | Description |
 | --- | --- | --- |
-|format| string| The coordinate system format.<br><br> There are several standard formats used to define coordinate reference systems. This extension doesn't adhere to a specific format, instead defines a `"format"` property whose value **MUST** be defined by additional extensions:<br><br><ul><li>[EXT_geospatial_crs_wkid](../EXT_geospatial_crs_wkid/README.md) - Well-Known ID, commonly used to represent EPSG codes. Defines format `"wkid"`</li><li>[EXT_geospatial_crs_wkt2](../EXT_geospatial_crs_wkt2/README.md) - Well-Known Text version 2. Defines format `"wkt2"`</li></ul><br>Additional extensions may define additional formats.|
+|format| string| The coordinate system format.|
+
+There are several standard formats used to define coordinate reference systems. This extension doesn't adhere to a specific format, instead defines a `"format"` property whose value **MUST** be defined by additional extensions:
+
+- [EXT_geospatial_crs_wkid](../EXT_geospatial_crs_wkid/README.md) - Well-Known ID, commonly used to represent EPSG codes. Defines format `"wkid"`
+- [EXT_geospatial_crs_wkt2](../EXT_geospatial_crs_wkt2/README.md) - Well-Known Text version 2. Defines format `"wkt2"
+
+Additional extensions may define additional formats.
 
 ### Node extension
 

--- a/extensions/2.1/Vendor/EXT_geospatial_crs_source/README.md
+++ b/extensions/2.1/Vendor/EXT_geospatial_crs_source/README.md
@@ -62,7 +62,6 @@ The content remains compatible with the coordinate reference system specified by
 }
 ```
 
-
 ```jsonc
 { // a node
   "boundingVolume": {...}, // ECEF bounding box (ignored in PCS mode)

--- a/extensions/2.1/Vendor/EXT_geospatial_crs_source/README.md
+++ b/extensions/2.1/Vendor/EXT_geospatial_crs_source/README.md
@@ -33,7 +33,7 @@ This extension allows an asset to specify its source coordinate reference system
 
 The content remains compatible with the coordinate reference system specified by [EXT_geospatial_crs](../EXT_geospatial_crs/README.md). For example, an asset may specify a projected coordinate system with `EXT_geospatial_crs_source` and a fallback geocentric coordinate system with `EXT_geospatial_crs`, as shown in the example below:
 
-``` json
+``` jsonc
 {
   "asset": {
     "version": "2.1"

--- a/extensions/2.1/Vendor/EXT_geospatial_crs_source/README.md
+++ b/extensions/2.1/Vendor/EXT_geospatial_crs_source/README.md
@@ -1,0 +1,101 @@
+<!--
+SPDX-FileCopyrightText: 2026 Bentley Systems, Incorporated
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# EXT\_geospatial\_crs\_source
+
+## Contributors
+
+- Ronald Poirrier, Esri
+- Jean-Philippe Pons, Esri
+- Tamrat Belayneh, Esri
+- Sean Lilley, Cesium
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the glTF 2.1 spec.
+
+Depends on [EXT_geospatial_crs](../EXT_geospatial_crs/README.md).
+
+## Optional
+
+This extension is optional, meaning it should be placed in the glTF root's `extensionsUsed` list, but not in the `extensionsRequired` list.
+
+## Overview
+
+This extension allows an asset to specify its source coordinate reference system (CRS) and supply additional transformation matrices to convert the content from its local model space to world space coordinate within the specified coordinate system.
+
+The content remains compatible with the coordinate reference system specified by [EXT_geospatial_crs](../EXT_geospatial_crs/README.md). For example, an asset may specify a projected coordinate system with `EXT_geospatial_crs_source` and a fallback geocentric coordinate system with `EXT_geospatial_crs`, as shown in the example below:
+
+``` json
+{
+  "asset": {
+    "version": "2.1"
+  },
+  "extensions": {
+    "EXT_geospatial_crs": {
+      "format": "wkid",
+      "extensions": {
+        "EXT_geospatial_crs_wkid": {
+          "authority": "EPSG",
+          "wkid": 4978 // WGS-84 Earth-centered, Earth-fixed
+        }
+      }
+    },
+    "EXT_geospatial_crs_source": {
+      "format": "wkid",
+      "extensions": {
+        "EXT_geospatial_crs_wkid": {
+          "authority": "EPSG",
+          "wkid": 31255,   // PCS MGI/Austria GK central
+          "vcsWkid": 5778  // VCS GHA height Austria (Gebrauchshohen ADRIA)
+        }
+      }
+    }
+  }
+}
+```
+
+
+```json
+{ // a node
+  "boundingVolume": {...}, // ECEF bounding box (ignored in PCS mode)
+  "matrix": [...], // ECEF transformation matrix (ignored in PCS mode)
+  "mesh": 0,
+  "extensions": {
+    "EXT_geospatial_crs_source": {
+      "boundingVolume": {...}, // PCS bounding box
+      "matrix": {...}, // PCS transformation matrix
+    }
+  }
+}
+```
+
+During traversal, the `EXT_geospatial_crs_source` transform may be used instead of the node transform to convert the content to projected coordinates. When the extension is not supported, the node transform is used and the asset falls back to geocentric coordinates.
+
+## Properties
+
+### Document-level extension
+
+| Property | Type | Description |
+| --- | --- | --- |
+|format| string| The coordinate system format.<br><br> There are several standard formats used to define coordinate reference systems. This extension doesn't adhere to a specific format, instead defines a `"format"` property whose value **MUST** be defined by additional extensions:<br><br><ul><li>[EXT_geospatial_crs_wkid](../EXT_geospatial_crs_wkid/README.md) - Well-Known ID, commonly used to represent EPSG codes. Defines format `"wkid"`</li><li>[EXT_geospatial_crs_wkt2](../EXT_geospatial_crs_wkt2/README.md) - Well-Known Text version 2. Defines format `"wkt2"`</li></ul><br>Additional extensions may define additional formats.|
+
+
+
+
+### Node extension
+
+| Property | Type | Description |
+| --- | --- | --- |       
+|boundingVolume| object| Is identical to `node.boundingVolume`. |
+|matrix|number[16]|Is identical to `node.matrix`.|
+|translation|number[3]|Is identical to `node.translation`.|
+|rotation|number[4]|Is identical to `node.rotation`.|
+|scale|number[3]|Is identical to `node.scale`.|

--- a/extensions/2.1/Vendor/EXT_geospatial_crs_source/README.md
+++ b/extensions/2.1/Vendor/EXT_geospatial_crs_source/README.md
@@ -87,9 +87,6 @@ During traversal, the `EXT_geospatial_crs_source` transform may be used instead 
 | --- | --- | --- |
 |format| string| The coordinate system format.<br><br> There are several standard formats used to define coordinate reference systems. This extension doesn't adhere to a specific format, instead defines a `"format"` property whose value **MUST** be defined by additional extensions:<br><br><ul><li>[EXT_geospatial_crs_wkid](../EXT_geospatial_crs_wkid/README.md) - Well-Known ID, commonly used to represent EPSG codes. Defines format `"wkid"`</li><li>[EXT_geospatial_crs_wkt2](../EXT_geospatial_crs_wkt2/README.md) - Well-Known Text version 2. Defines format `"wkt2"`</li></ul><br>Additional extensions may define additional formats.|
 
-
-
-
 ### Node extension
 
 | Property | Type | Description |

--- a/extensions/2.1/Vendor/EXT_geospatial_crs_source/README.md
+++ b/extensions/2.1/Vendor/EXT_geospatial_crs_source/README.md
@@ -63,7 +63,7 @@ The content remains compatible with the coordinate reference system specified by
 ```
 
 
-```json
+```jsonc
 { // a node
   "boundingVolume": {...}, // ECEF bounding box (ignored in PCS mode)
   "matrix": [...], // ECEF transformation matrix (ignored in PCS mode)

--- a/extensions/2.1/Vendor/EXT_geospatial_crs_source/REUSE.toml
+++ b/extensions/2.1/Vendor/EXT_geospatial_crs_source/REUSE.toml
@@ -1,0 +1,6 @@
+version = 1
+
+[[annotations]]
+path = ["figures/**/*.jpg", "schema/**/*.schema.json"]
+SPDX-FileCopyrightText = "2026 Bentley Systems, Incorporated"
+SPDX-License-Identifier = "CC-BY-4.0"

--- a/extensions/2.1/Vendor/EXT_geospatial_crs_source/schema/glTF.EXT_geospatial_crs_source.schema.json
+++ b/extensions/2.1/Vendor/EXT_geospatial_crs_source/schema/glTF.EXT_geospatial_crs_source.schema.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "glTF.EXT_geospatial_crs_source.schema.json",
+    "title": "EXT_geospatial_crs_source glTF Document extension",
+    "type": "object",
+    "description": "This extension allows an asset to specify its source coordinate reference system (CRS) and supply additional transformation matrices that convert the content from its local model space to world space coordinate within the specified coordinate system.",
+    "$ref": "glTFProperty.schema.json",
+    "properties": {
+        "format": {
+            "type": "string",
+            "description": "The coordinate reference system format, whose value must be defined by additional extensions."
+        }
+    },
+    "required": [
+        "format"
+    ]
+}

--- a/extensions/2.1/Vendor/EXT_geospatial_crs_source/schema/node.EXT_geospatial_crs_source.schema.json
+++ b/extensions/2.1/Vendor/EXT_geospatial_crs_source/schema/node.EXT_geospatial_crs_source.schema.json
@@ -1,0 +1,59 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "node.EXT_geospatial_crs_source.schema.json",
+    "title": "EXT_geospatial_crs_source Node extension",
+    "type": "object",
+    "description": "Supplies additional transformation matrices that convert the content from its local model space to world space coordinate within the specified coordinate system.",
+    "$ref": "glTFProperty.schema.json",
+    "properties": {
+        "matrix": {
+            "type": "array",
+            "description": "A floating-point 4x4 transformation matrix stored in column-major order.",
+            "items": {
+                "type": "number"
+            },
+            "minItems": 16,
+            "maxItems": 16,
+            "default": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ],
+        },
+        "rotation": {
+            "type": "array",
+            "description": "A unit quaternion rotation in the order (x, y, z, w), where w is the scalar.",
+            "items": {
+                "type": "number",
+                "minimum": -1.0,
+                "maximum": 1.0
+            },
+            "minItems": 4,
+            "maxItems": 4,
+            "default": [ 0.0, 0.0, 0.0, 1.0 ]
+        },
+        "scale": {
+            "type": "array",
+            "description": "A non-uniform scale, given as the scaling factors along the x, y, and z axes.",
+            "items": {
+                "type": "number"
+            },
+            "minItems": 3,
+            "maxItems": 3,
+            "default": [ 1.0, 1.0, 1.0 ]
+        },
+        "translation": {
+            "type": "array",
+            "description": "A translation along the x, y, and z axes.",
+            "items": {
+                "type": "number"
+            },
+            "minItems": 3,
+            "maxItems": 3,
+            "default": [ 0.0, 0.0, 0.0 ]
+        }
+    },
+    "not": {
+        "anyOf": [
+            { "required": [ "matrix", "translation" ] },
+            { "required": [ "matrix", "rotation" ] },
+            { "required": [ "matrix", "scale" ] }
+        ]
+    }
+}


### PR DESCRIPTION
[Link to extension](https://github.com/CesiumGS/glTF/tree/3d-tiles-2.0-EXT_geospatial_crs_source/extensions/2.1/Vendor/EXT_geospatial_crs_source)

This is a follow up extension to [EXT_geospatial_crs](https://github.com/CesiumGS/glTF/tree/3d-tiles-2.0/extensions/2.1/Vendor/EXT_geospatial_crs) that allows an asset to specify its source coordinate system and override node transforms to recover the original source coordinates. This is a successor to [ESRI_crs](https://github.com/Esri/3D-tiles-layer/blob/main/ESRI_CRS/Esri_crs_extension.md) that works alongside `EXT_geospatial_crs`. For more background see the original PR: https://github.com/CesiumGS/3d-tiles/pull/830.