### PR TITLE
Fixing errata with the 3DTILES_shapes_* extensions

### DIFF
--- a/extensions/2.1/Vendor/3DTILES_shape_cylinder_region/README.md
+++ b/extensions/2.1/Vendor/3DTILES_shape_cylinder_region/README.md
@@ -32,7 +32,7 @@ This extension is required, meaning it **MUST** be placed in both `extensionsReq
 
 This extension defines a cylinder-conforming region as an additional shape type for glTF 2.1 shapes. These regions are useful for visualizing real-world data that has been captured by cylindrical sensors.
 
-`3DTILES_shape_cylinder_region` extends the `shape` object in glTF 2.1. The `shape.type` **MUST** be set to `"cylinder region"`.
+`3DTILES_shape_cylinder_region` extends the `shape` object in glTF 2.1. The `shape.type` **MUST** be set to `"cylinder region"`. This shape **MAY** be used as an additional shape type for bounding volumes or by extensions.
 
 The `minimumRadius`, `maximumRadius`, and `height` properties are required. These properties define a region following the surface of a cylinder between two different radius values. Two optional properties, `minimumAngle` and `maximumAngle`, define the maximum angle of the cylinder region in radians.
 

--- a/extensions/2.1/Vendor/3DTILES_shape_ellipsoid_region/README.md
+++ b/extensions/2.1/Vendor/3DTILES_shape_ellipsoid_region/README.md
@@ -34,7 +34,7 @@ This extension defines an ellipsoid-conforming region as an additional shape typ
 
 The volume does not necessarily contain the full ellipsoid—and for many geospatial use cases, it will not. Rather, the ellipsoid is used as a reference from which the actual region is extruded. However, a region may extend beneath the surface of the ellipsoid. Given the right height values, the region could contain the entire ellipsoid if desired.
 
-This extension **MAY** only be used by tilesets in a [global coordinate system](../3DTILES_tileset/README.md#coordinate-reference-system-crs). This extension uses the ellipsoid specified by [EXT_geospatial_crs](../EXT_geospatial_crs/README.md).
+This extension **SHOULD** only be used by tilesets in a [global coordinate system](../3DTILES_tileset/README.md#coordinate-reference-system-crs). This extension uses the ellipsoid specified by [EXT_geospatial_crs](../EXT_geospatial_crs/README.md). This shape **MAY** be used as an additional shape type for bounding volumes or by extensions.
 
 Tile transforms do not apply to bounding volumes referencing ellipsoid region shapes. Tiles using this extension must maintain [spatial coherence](../3DTILES_tileset/README.md#spatial-coherence). This extension may be applied to tile or content bounding volumes. See [`3DTILES_tileset`](../3DTILES_tileset/README.md#transforms) for more details.
 

--- a/extensions/2.1/Vendor/3DTILES_shape_s2/README.md
+++ b/extensions/2.1/Vendor/3DTILES_shape_s2/README.md
@@ -51,7 +51,7 @@ Typically, traditional GIS libraries rely on projecting map data from an ellipso
 
 This extension defines S2 cells as an additional shape type for glTF 2.1 shapes. Due to the properties of S2 described above, this shape is well suited for tilesets that span the whole globe.
 
-This extension **MAY** only be used by tilesets in a [global coordinate system](../3DTILES_tileset/README.md#coordinate-reference-system-crs). This extension uses the ellipsoid specified by [EXT_geospatial_crs](../EXT_geospatial_crs/README.md).
+This extension **SHOULD** only be used by tilesets in a [global coordinate system](../3DTILES_tileset/README.md#coordinate-reference-system-crs). This extension uses the ellipsoid specified by [EXT_geospatial_crs](../EXT_geospatial_crs/README.md). This shape **MAY** be used as an additional shape type for bounding volumes or by extensions.
 
 Tile transforms do not apply to bounding volumes referencing S2 shapes. Tiles using this extension must maintain [spatial coherence](../3DTILES_tileset/README.md#spatial-coherence). This extension may be applied to tile or content bounding volumes. See [`3DTILES_tileset`](../3DTILES_tileset/README.md#transforms) for more details.
 


### PR DESCRIPTION
This PR fixes errata with the 3D Tiles 2.0 shape extensions. The intent has always been to allow the cylinder, ellipsoid, and S2 shape types to be used as bounding volume shapes. While we have the [necessary language in the 3DTILES_tileset extension](https://github.com/CesiumGS/glTF/tree/3d-tiles-2.0/extensions/2.1/Vendor/3DTILES_tileset#bounding-volumes), the shapes extensions themselves were lacking explicit language permitting them to be used as bounding volumes. Thank you to @bjornblissing for pointing this out to us.

Each extension now has a statement explicitly allowing them to be used as an additional shape type for bounding volumes. To make it clear that this is not exclusive to bounding volumes I added, "or by extensions," to each statement. That additional bit isn't actually required per glTF specification guidance, but it at adds some clarity for the reader.

I also fixed a related error that I found with `3DTILES_shape_ellipsoid_region` and `3DTILES_shape_s2`. In both cases the statement that they should be used by tilesets in a global coordinate system is a **MAY** when it should be a **SHOULD**. **MAY** indicates optionality, but these statements are meant as recommendations with a YMMV aspect if you diverge from the recommendation. Those have been changed to **SHOULD** to be more in line with that recommendation.