### PR TITLE
Made EXT_georeference an optional extension

### DIFF
--- a/extensions/2.1/Vendor/EXT_georeference/README.md
+++ b/extensions/2.1/Vendor/EXT_georeference/README.md
@@ -19,9 +19,9 @@ Draft
 
 Written against the glTF 2.1 spec.
 
-## Required
+## Optional
 
-This extension is required, meaning it **MUST** be placed in both `extensionsRequired` and `extensionsUsed`.
+This extension is optional, meaning it should be placed in the glTF root's `extensionsUsed` list, but not in the `extensionsRequired` list.
 
 ## Overview
 


### PR DESCRIPTION
The preferred norm in the glTF world is that extensions that do not cause critical failures—crashes, overflows, etc.—are not mandated by specification to be in `extensionsRequired`. There are occasional exceptions made for use cases, but it's discouraged.

`EXT_georeference` was marked as a required extension but this is incorrect. @lilleyse and I talked about it and agreed that it needs to be fixed. This is especially true for this extension since in many cases, a georeferenced node lives in a local space within the file and will render fine.

This doesn't prevent content creators from putting the extension in `requiredExtensions`. The 3D Formats Working Group has been clear over the years that content creators are welcome to put any extension they feel is required for viewing their content in that field. We shouldn't however mandate it unless it's truly required.